### PR TITLE
corrige rake task en README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ cd participacion
 bundle install
 cp config/database.yml.example config/database.yml
 cp config/secrets.yml.example config/secrets.yml
-bundle exec bin/rake db:create db:schema_load
-RAILS_ENV=test bundle exec rake db:create db:schema_load
+bundle exec bin/rake db:create db:schema:load
+RAILS_ENV=test bundle exec rake db:create db:schema:load
 ```
 
 Para ejecutar la aplicación en local:


### PR DESCRIPTION
la sintaxis para cargar schema.db en la base de datos es `rake db:schema:load`