### PR TITLE
Debates title length

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -1,5 +1,8 @@
 require 'numeric'
 class Debate < ActiveRecord::Base
+
+  TITLE_LENGTH = Debate.columns.find{|c| c.name == 'title'}.limit
+
   acts_as_votable
   acts_as_commentable
   acts_as_taggable

--- a/app/views/debates/_form.html.erb
+++ b/app/views/debates/_form.html.erb
@@ -12,7 +12,7 @@
 
     <p><strong><%= t("debates.form.debate_title") %></strong></p>
     <p><%= t("debates.form.title_instructions") %></p>
-    <%= f.text_field :title %>
+    <%= f.text_field :title, maxlength: Debate::TITLE_LENGTH %>
 
   <br/>
   <p><strong><%= t("debates.form.debate_text") %></strong></p>

--- a/db/migrate/20150806111435_change_debates_title_length.rb
+++ b/db/migrate/20150806111435_change_debates_title_length.rb
@@ -1,0 +1,5 @@
+class ChangeDebatesTitleLength < ActiveRecord::Migration
+  def change
+    change_column :debates, :title, :string, limit: 80
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150731110702) do
+ActiveRecord::Schema.define(version: 20150806111435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,11 +34,11 @@ ActiveRecord::Schema.define(version: 20150731110702) do
   add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree
 
   create_table "debates", force: :cascade do |t|
-    t.string   "title"
+    t.string   "title",       limit: 80
     t.text     "description"
     t.integer  "author_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   create_table "taggings", force: :cascade do |t|


### PR DESCRIPTION
Sets the de length of Debate.title to 80 in both the database and the input form. Fixes #93