### PR TITLE
adds and activates fuubar when running the specs. 

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
+--format Fuubar
 --color
+

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.0'
   gem 'capybara'
   gem 'factory_girl_rails'
+  gem 'fuubar'
   gem 'launchy'
   gem 'quiet_assets'
   gem 'letter_opener_web', '~> 1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
       activesupport (~> 4.1, >= 4.1.1)
       railties (~> 4.1, >= 4.1.1)
       tzinfo (~> 1.2, >= 1.2.2)
+    fuubar (2.0.0)
+      rspec (~> 3.0)
+      ruby-progressbar (~> 1.4)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     highline (1.7.3)
@@ -224,6 +227,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -241,6 +248,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    ruby-progressbar (1.7.5)
     sass (3.4.16)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -327,6 +335,7 @@ DEPENDENCIES
   factory_girl_rails
   foundation-rails
   foundation_rails_helper
+  fuubar
   i18n-tasks
   initialjs-rails
   jquery-rails


### PR DESCRIPTION
[fuubar](https://github.com/thekompanee/fuubar) is an rspec formatter which "displays the errors as they happen".

So instead of seeing something like this:

```
.....................F..........F...................
```
And having to wait until the tests finish, `fuubar` immediately prints the relevant information about the failed tests as soon as they happen - you don't have to wait.

Related with #189 (we would not need fuubar if the tests were almost instant) 