### PR TITLE
Added ghostscript to Readme. Required for captcha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 
 # Mac finder artifacts
 .DS_Store
+.ruby-gemset

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Las herramientas utilizadas para el frontend no están cerradas aún. Los estilo
 
 ## Configuración para desarrollo y tests
 
-Prerequisitos: tener instalado git, ImageMagick, Ruby 2.2.2, la gema `bundler`, y PostgreSQL (9.4 o superior).
+Prerequisitos: tener instalado git, ImageMagick, Ruby 2.2.2, la gema `bundler`, ghostscript y PostgreSQL (9.4 o superior).
 
 ```
 cd participacion

--- a/README_EN.md
+++ b/README_EN.md
@@ -21,7 +21,7 @@ Frontend tools used include [SCSS](http://sass-lang.com/) over [Foundation](http
 
 ## Configuration for development and test environments
 
-Prerequisites: install git, ImageMagick, Ruby 2.2.2, bundler gem and PostgreSQL (>=9.4).
+Prerequisites: install git, ImageMagick, Ruby 2.2.2, bundler gem, ghostscript and PostgreSQL (>=9.4).
 
 ```
 cd participacion


### PR DESCRIPTION
One test was failing apparently cause ghostscript was missing.
All test passing after `brew install ghostscript`
 I thought would be nice to include in the README file