### PR TITLE
Do not show links to moderate own content

### DIFF
--- a/app/assets/javascripts/moderator_comment.js.coffee
+++ b/app/assets/javascripts/moderator_comment.js.coffee
@@ -4,4 +4,4 @@ App.ModeratorComments =
     $("##{id} .comment-body:first").addClass("faded")
 
   hide_moderator_actions: (id) ->
-    $("##{id} #moderator-comment-actions:first").hide()
+    $("##{id} .js-moderator-comment-actions").hide()

--- a/app/assets/javascripts/moderator_debates.js.coffee
+++ b/app/assets/javascripts/moderator_debates.js.coffee
@@ -5,4 +5,4 @@ App.ModeratorDebates =
     $("#comments").addClass("faded")
 
   hide_moderator_actions: (id) ->
-    $("##{id} #moderator-debate-actions:first").hide()
+    $("##{id} .js-moderator-debate-actions:first").hide()

--- a/app/views/comments/_actions.html.erb
+++ b/app/views/comments/_actions.html.erb
@@ -1,8 +1,11 @@
-  &nbsp;|&nbsp;
-  <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
-              method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
-  <% unless comment.user.hidden? %>
 <span class='js-moderation-actions'>
+  <% if can? :hide, comment %>
+    &nbsp;|&nbsp;
+    <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
+                method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
+  <% end %>
+
+  <% if can? :hide, comment.user %>
     &nbsp;|&nbsp;
     <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(comment.user_id, debate_id: @debate.id),
                 method: :put, data: { confirm: t('admin.actions.confirm') } %>

--- a/app/views/comments/_actions.html.erb
+++ b/app/views/comments/_actions.html.erb
@@ -1,8 +1,8 @@
-<span id="moderator-comment-actions">
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide").capitalize, hide_moderation_comment_path(comment),
               method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
   <% unless comment.user.hidden? %>
+<span class='js-moderation-actions'>
     &nbsp;|&nbsp;
     <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(comment.user_id, debate_id: @debate.id),
                 method: :put, data: { confirm: t('admin.actions.confirm') } %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -69,9 +69,7 @@
             <%= link_to(comment_link_text(comment), "",
                         class: "js-add-comment-link", data: {'id': dom_id(comment)}) %>
 
-            <% if moderator? %>
-               <%= render 'comments/actions', comment: comment %>
-            <% end %>
+            <%= render 'comments/actions', comment: comment %>
 
             <%= render 'comments/form', {parent: comment, toggeable: true} %>
           <% end %>

--- a/app/views/debates/_actions.html.erb
+++ b/app/views/debates/_actions.html.erb
@@ -1,7 +1,9 @@
-<%= link_to t("admin.actions.hide").capitalize, hide_moderation_debate_path(debate),
-            method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
+<% if can? :hide, debate %>
+  <%= link_to t("admin.actions.hide").capitalize, hide_moderation_debate_path(debate),
+              method: :put, remote: true, data: { confirm: t('admin.actions.confirm') } %>
+<% end %>
 
-<% unless debate.author.hidden? %>
+<% if can? :hide, debate.author %>
   &nbsp;|&nbsp;
   <%= link_to t("admin.actions.hide_author").capitalize, hide_moderation_user_path(debate.author_id),
               method: :put, data: { confirm: t('admin.actions.confirm') } %>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -52,7 +52,7 @@
       <%= render 'shared/tags', debate: @debate %>
 
       <% if moderator? %>
-        <div id='moderator-debate-actions'>
+        <div class='js-moderator-debate-actions'>
           <%= render 'actions', debate: @debate %>
         </div>
       <% end %>

--- a/spec/features/moderation/comments_spec.rb
+++ b/spec/features/moderation/comments_spec.rb
@@ -59,17 +59,38 @@ feature 'Moderate Comments' do
     moderator = create(:moderator)
 
     debate = create(:debate)
-    create(:comment, commentable: debate)
+    comment = create(:comment, commentable: debate)
 
     login_as(moderator.user)
     visit debate_path(debate)
 
-    expect(page).to have_css("#moderator-comment-actions")
+    within "#comment_#{comment.id}" do
+      expect(page).to have_link("Hide")
+      expect(page).to have_link("Ban author")
+    end
 
     login_as(citizen)
     visit debate_path(debate)
 
-    expect(page).to_not have_css("#moderator-comment-actions")
+    within "#comment_#{comment.id}" do
+      expect(page).to_not have_link("Hide")
+      expect(page).to_not have_link("Ban author")
+    end
+  end
+
+  scenario 'Moderator actions do not appear in own comments' do
+    moderator = create(:moderator)
+
+    debate = create(:debate)
+    comment = create(:comment, commentable: debate, user: moderator.user)
+
+    login_as(moderator.user)
+    visit debate_path(debate)
+
+    within "#comment_#{comment.id}" do
+      expect(page).to_not have_link("Hide")
+      expect(page).to_not have_link("Ban author")
+    end
   end
 
   feature '/moderation/ menu' do

--- a/spec/features/moderation/debates_spec.rb
+++ b/spec/features/moderation/debates_spec.rb
@@ -23,6 +23,19 @@ feature 'Moderate debates' do
     expect(page).to have_css('.debate', count: 0)
   end
 
+  scenario 'Can not hide own debate' do
+    moderator = create(:moderator)
+    debate = create(:debate, author: moderator.user)
+
+    login_as(moderator.user)
+    visit debate_path(debate)
+
+    within("#debate_#{debate.id}") do
+      expect(page).to_not have_link('Hide')
+      expect(page).to_not have_link('Block author')
+    end
+  end
+
   feature '/moderation/ menu' do
 
     background do


### PR DESCRIPTION
This PR does two things:

* It replaces duplicated `#javascript-ids` with `.js-classes` in the container of the moderation actions for debates and comments
* It changes the logic on the link generation to use cancancan - this way, a user can not:
  * hide his own comments
  * hide his own debates
  * or hide himself

(The server already forbids this, but the logic in the views was not aligned with it)