### PR TITLE
Adds different avatar for users with names with the same initial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'simple_captcha2', require: 'simple_captcha'
 gem 'ckeditor'
 gem 'cancancan'
 gem 'social-share-button'
-gem 'initialjs-rails'
+gem 'initialjs-rails', '0.2.0'
 gem 'unicorn'
 gem 'paranoia'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
       i18n
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
-    initialjs-rails (0.1.0)
+    initialjs-rails (0.2.0)
       railties (>= 3.1, < 5.0)
     jquery-rails (4.0.4)
       rails-dom-testing (~> 1.0)
@@ -357,7 +357,7 @@ DEPENDENCIES
   fuubar
   groupdate
   i18n-tasks
-  initialjs-rails
+  initialjs-rails (= 0.2.0)
   jquery-rails
   kaminari
   launchy

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -26,7 +26,7 @@
 
         <div class="small-12 medium-6 column">
           <h2><%= t("account.show.avatar")%></h2>
-          <%= avatar_image(@account, size: 100) %>
+          <%= avatar_image(@account, seed: @account.id, size: 100) %>
 
           <h2><%= t("account.show.notifications")%></h2>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -14,7 +14,7 @@
         <% if comment.user.organization? %>
           <%= image_tag("collective_avatar.png", size: 32, class: "avatar left") %>
         <% else %>
-          <%= avatar_image(comment.user, size: 32, class: "left") %>
+          <%= avatar_image(comment.user, seed: comment.user_id, size: 32, class: "left") %>
         <% end %>
         <% if comment.user.hidden? %>
           <i class="icon-deleted user-deleted"></i>

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -13,7 +13,7 @@
       <h1><%= @debate.title %></h1>
 
       <div class="debate-info">
-        <%= avatar_image(@debate.author, size: 32, class: 'author-photo') %>
+        <%= avatar_image(@debate.author, seed: @debate.author_id, size: 32, class: 'author-photo') %>
         <% if @debate.author.hidden? %>
           <i class="icon-deleted author-deleted"></i>
           <span class="author">


### PR DESCRIPTION
This PR updates the version of the initialjs-rails gem, that includes a seed option to randomize individual users' avatar with a number. Using the user's id we can have different avatar color for users with the same initials.
