### PR TITLE
Add filters to debates index page

### DIFF
--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -1,4 +1,5 @@
 class DebatesController < ApplicationController
+  before_action :parse_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show]
 
   load_and_authorize_resource
@@ -69,6 +70,11 @@ class DebatesController < ApplicationController
 
     def load_featured_tags
       @featured_tags = ActsAsTaggableOn::Tag.where(featured: true)
+    end
+
+    def parse_filter
+      @valid_filters = ['votes', 'news', 'rated']
+      @filter = @valid_filters.include?(params[:filter]) ? params[:filter] : 'news'
     end
 
 end

--- a/app/helpers/debates_helper.rb
+++ b/app/helpers/debates_helper.rb
@@ -1,0 +1,8 @@
+module DebatesHelper
+
+  def sort_debates(debates, filter)
+    sort_criteria = {'votes' => :total_votes, 'news' => :created_at, 'rated' => :likes}
+    debates.sort_by(&sort_criteria[filter]).reverse
+  end
+
+end

--- a/app/views/debates/_filter_selector.erb
+++ b/app/views/debates/_filter_selector.erb
@@ -1,0 +1,7 @@
+<% options = @valid_filters.map { |f| [t("debates.index.filter_#{f}"), f] } %>
+
+<%= form_tag('/debates', method: 'get', class: 'inline-block') do %>
+
+  <%= select_tag 'filter', options_for_select(options, @filter), onchange: "this.form.submit()" %>
+
+<% end %>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -4,18 +4,7 @@
   <div class="filters row">
     <div class="small-12 column">
       <h2><%= t("debates.index.showing") %></h2>
-
-      <select class="inline-block">
-        <option value="filter_news">
-          <%= t("debates.index.filter_news") %>
-        </option>
-        <option value="filter_votes">
-          <%= t("debates.index.filter_votes") %>
-        </option>
-        <option value="filter_rated">
-          <%= t("debates.index.filter_rated") %>
-        </option>
-      </select>
+      <%= render 'filter_selector' %>
     </div>
   </div>
   <!-- /. Filters -->
@@ -34,7 +23,7 @@
 
   <div class="row">
     <div id="debates" class="debates-list small-12 medium-9 column">
-      <%= render @debates %>
+      <%= render sort_debates(@debates, @filter) %>
       <%= paginate @debates %>
     </div>
     <div class="small-12 medium-3 column">


### PR DESCRIPTION
Allows user to select one of three filters to specify the order in which debates are listed on /debates page. 'Sort by newest' is the default. Issue #193

All tests pass except for "I18n does not have unused keys" as some of these are generated dynamically in app/views/debates/_filter_selector.erb