### PR TITLE
Simplificar algunos commandos redundantes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ cd participacion
 bundle install
 cp config/database.yml.example config/database.yml
 cp config/secrets.yml.example config/secrets.yml
-bundle exec bin/rake db:setup
-RAILS_ENV=test bundle exec rake db:setup
+bin/rake db:setup
+RAILS_ENV=test bin/rake db:setup
 ```
 
 Para ejecutar la aplicación en local:
 ```
-bundle exec bin/rails s
+bin/rails s
 ```
 
 Prerequisitos para los tests: tener instalado PhantomJS >= 2.0
@@ -41,7 +41,7 @@ Prerequisitos para los tests: tener instalado PhantomJS >= 2.0
 Para ejecutar los tests:
 
 ```
-bundle exec bin/rspec
+bin/rspec
 ```
 
 ### OAuth

--- a/README_EN.md
+++ b/README_EN.md
@@ -28,13 +28,13 @@ cd participacion
 bundle install
 cp config/database.yml.example config/database.yml
 cp config/secrets.yml.example config/secrets.yml
-bundle exec bin/rake db:setup
-RAILS_ENV=test bundle exec rake db:setup
+bin/rake db:setup
+RAILS_ENV=test bin/rake db:setup
 ```
 
 Run the app locally:
 ```
-bundle exec bin/rails s
+bin/rails s
 ```
 
 Prerequisites for testing: install PhantomJS >= 2.0
@@ -42,7 +42,7 @@ Prerequisites for testing: install PhantomJS >= 2.0
 Run the tests with:
 
 ```
-bundle exec bin/rspec
+bin/rspec
 ```
 
 ## Licence


### PR DESCRIPTION
Buenas! Leyendo el README me surgió este pequeño cambio. En realidad buscaba una excusa para saludar y felicitaros (a vosotros y a quién sea que esté detrás de esto y le haya dado luz verde) por esta iniciativa. Es genial ver que desde el Ayuntamiento se impulsa el software libre de esta manera. :+1: 

Respecto a los cambios, ya lo explico en el mensaje del commit. Creo que usar `bundle exec` no es necesario ya que los scripts en `bin` ya requieren `bundler` para asegurar que se use la versión correcta de cada librería. (Qué raro se me hace explicar estas cosas en castellano!)

Salud!