### PR TITLE
Bullet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem "capistrano-bundler", '1.1.4',   require: false
   gem "capistrano-rails", '1.1.3',     require: false
   gem "capistrano-rvm",                require: false
+  gem "bullet"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       debug_inspector (>= 0.0.1)
     browser (0.9.1)
     builder (3.2.2)
+    bullet (4.14.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.9.0)
     byebug (6.0.2)
     cancancan (1.12.0)
     capistrano (3.4.0)
@@ -345,6 +348,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    uniform_notifier (1.9.0)
     user_agent_parser (2.2.0)
     uuidtools (2.1.5)
     warden (1.2.3)
@@ -368,6 +372,7 @@ DEPENDENCIES
   acts_as_commentable_with_threading
   acts_as_votable
   ahoy_matey (~> 1.2.1)
+  bullet
   byebug
   cancancan
   capistrano (= 3.4.0)

--- a/app/controllers/admin/officials_controller.rb
+++ b/app/controllers/admin/officials_controller.rb
@@ -1,11 +1,11 @@
 class Admin::OfficialsController < Admin::BaseController
 
   def index
-    @officials = User.officials.page(params[:page])
+    @officials = User.officials.page(params[:page]).for_render
   end
 
   def search
-    @users = User.with_email(params[:email]).page(params[:page])
+    @users = User.with_email(params[:email]).page(params[:page]).for_render
   end
 
   def edit

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -11,7 +11,7 @@ class DebatesController < ApplicationController
 
   def show
     set_debate_votes(@debate)
-    @comments = @debate.root_comments.with_hidden.includes(:inappropiate_flags).recent.page(params[:page])
+    @comments = @debate.root_comments.recent.page(params[:page]).for_render
   end
 
   def new

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -5,7 +5,7 @@ class DebatesController < ApplicationController
   respond_to :html, :js
 
   def index
-    @debates = Debate.includes(:tags).includes(:inappropiate_flags).search(params).page(params[:page])
+    @debates = Debate.search(params).page(params[:page]).for_render
     set_debate_votes(@debates)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,13 +14,14 @@ class Comment < ActiveRecord::Base
 
   has_many :inappropiate_flags, :as => :flaggable
 
-  default_scope { includes(:user) }
   scope :recent, -> { order(id: :desc) }
 
   scope :sorted_for_moderation, -> { order(inappropiate_flags_count: :desc, updated_at: :desc) }
   scope :pending, -> { where(archived_at: nil, hidden_at: nil) }
   scope :archived, -> { where("archived_at IS NOT NULL AND hidden_at IS NULL") }
   scope :flagged_as_inappropiate, -> { where("inappropiate_flags_count > 0") }
+
+  scope :for_render, -> { with_hidden.includes(user: :organization) }
 
   def self.build(commentable, user, body)
     new commentable: commentable,

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -27,6 +27,7 @@ class Debate < ActiveRecord::Base
   scope :pending, -> { where(archived_at: nil, hidden_at: nil) }
   scope :archived, -> { where("archived_at IS NOT NULL AND hidden_at IS NULL") }
   scope :flagged_as_inappropiate, -> { where("inappropiate_flags_count > 0") }
+  scope :for_render, -> { includes(:tags) }
 
   # Ahoy setup
   visitable # Ahoy will automatically assign visit_id on create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,11 @@ class User < ActiveRecord::Base
 
   accepts_nested_attributes_for :organization
 
-  default_scope { includes(:organization) }
   scope :administrators, -> { joins(:administrators) }
   scope :moderators,     -> { joins(:moderator) }
   scope :organizations,  -> { joins(:organization) }
   scope :officials,      -> { where("official_level > 0") }
+  scope :for_render,     -> { includes(:organization) }
 
   def self.find_for_oauth(auth, signed_in_resource = nil)
     # Get the identity and user if they exist

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -95,7 +95,7 @@
     <% end %>
 
       <div class="comment-children">
-        <%= render comment.children.with_hidden.reorder('id DESC, lft') %>
+        <%= render comment.children.for_render.reorder('id DESC, lft') %>
       </div>
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,13 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.cache_store = :null_store
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    if ENV['BULLET']
+      Bullet.rails_logger = true
+      Bullet.add_footer = true
+    end
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,13 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.cache_store = :null_store
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    if ENV['BULLET']
+      Bullet.raise = true # raise an error if n+1 query occurs
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,15 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  config.before(:each, type: :feature) do
+    Bullet.start_request
+  end
+
+  config.after(:each, type: :feature) do
+    Bullet.perform_out_of_channel_notifications if Bullet.notification?
+    Bullet.end_request
+  end
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options.
   config.example_status_persistence_file_path = "spec/examples.txt"
@@ -57,4 +66,6 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+
 end


### PR DESCRIPTION
This PR:

* Adds bullet in development and test
* By default bullet is silent and only logs to log/bullet.log
* Running the specs with `BULLET=true bin/rspec` will make the feature test with N+1, missing counts, etc fail
* Running development with `BULLET=true bin/rails s` will write bullet errors in the rails log and include the bullet footer at the bottom of each page

This PR also fixes some obvious eager loading problems which I have found while running the tests with bullet (unused / missing eager loadings)