### PR TITLE
Allow debates to be filtered by topic

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@ var initialize_modules = function() {
   App.Stats.initialize();
   App.LocaleSwitcher.initialize();
   App.DebatesOrderSelector.initialize();
+  App.DebatesTagFilter.initialize();
 };
 
 $(function(){

--- a/app/assets/javascripts/debates_tag_filter.js.coffee
+++ b/app/assets/javascripts/debates_tag_filter.js.coffee
@@ -1,0 +1,17 @@
+App.DebatesTagFilter =
+
+  href_with_params: (query_params) ->
+    loc = window.location
+
+    loc.protocol + "//" + loc.hostname +
+      (if loc.port then ':' + loc.port else '') +
+      loc.pathname +
+      loc.hash +
+      '?' + $.param(query_params)
+
+  initialize: ->
+    $('.js-tag-filter').on 'change', ->
+      query_params = window.getQueryParameters()
+      query_params['tag'] = $(this).val()
+      window.location.assign(App.DebatesTagFilter.href_with_params(query_params))
+

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -1,5 +1,5 @@
 class DebatesController < ApplicationController
-  before_action :parse_order, only: :index
+  before_action :parse_order, :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show]
 
   load_and_authorize_resource
@@ -75,6 +75,11 @@ class DebatesController < ApplicationController
     def parse_order
       @valid_orders = ['total_votes', 'created_at', 'likes']
       @order = @valid_orders.include?(params[:order]) ? params[:order] : 'created_at'
+    end
+
+    def parse_tag_filter
+      valid_tags = ActsAsTaggableOn::Tag.all.map(&:name)
+      @tag_filter = params[:tag] if valid_tags.include?(params[:tag])
     end
 
 end

--- a/app/views/debates/_order_selector.erb
+++ b/app/views/debates/_order_selector.erb
@@ -1,5 +1,0 @@
-<form class="inline-block">
-   <select class="js-order-selector" name="order-selector"> 
-     <%= available_options_for_order_selector(@valid_orders, @order) %>
-   </select>
-</form>

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -4,7 +4,11 @@
   <div class="filters row">
     <div class="small-12 column">
       <h2><%= t("debates.index.showing") %></h2>
-      <%= render 'order_selector' %>
+      <form class="inline-block">
+         <select class="js-order-selector" name="order-selector"> 
+           <%= available_options_for_order_selector(@valid_orders, @order) %>
+         </select>
+      </form>
     </div>
   </div>
   <!-- /. Filters -->

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -1,41 +1,37 @@
 <section role="main">
 
-  <!-- Filters -->
   <div class="filters row">
-    <div class="small-12 column">
-      <h2><%= t("debates.index.showing") %></h2>
-      <form class="inline-block">
-         <select class="js-order-selector" name="order-selector"> 
-           <%= available_options_for_order_selector(@valid_orders, @order) %>
-         </select>
-      </form>
-    </div>
-  </div>
-  <!-- /. Filters -->
+    <div class="small-9 column">
 
-  <!-- Filter topic results -->
-  <div class="filters row">
-    <div class="small-12 column">
-      <% if @tag_filter %>
-        <h2>
-          <%= t("debates.index.filter_topic",
-                 number: @debates.size,
-                 # TODO translation
-                 topic: @tag_filter).html_safe %>
-        </h2>
-      <% else %>
-        <h2>Filtrar por tema:  </h2>
+      <div class="inline-block" >
+        <% if @tag_filter %>
+          <h2>
+            <%= t("debates.index.filter_topic",
+                   number: @debates.size,
+                   topic: @tag_filter).html_safe %>
+          </h2>
+        <% else %>
+          <h2><%= t("debates.index.select_topic") %></h2>
+          <form class="inline-block">
+             <select class="js-tag-filter" name="tag-filter"> 
+               <option value="all" selected="selected"><%= t("debates.index.all") %></option>
+               <%= options_from_collection_for_select(ActsAsTaggableOn::Tag.all, :name, :name) %>
+             </select>
+          </form>
+        <% end %>
+      </div>
+
+      <div class="inline-block right">
+        <h6 class="inline-block"><%= t("debates.index.select_order") %></h6>
         <form class="inline-block">
-           <select class="js-tag-filter" name="tag-filter"> 
-             <%# select_tag 'tag-filter', nil, {prompt: 'Temas --', class: 'js-tag-filter'} do %>
-             <option value="default" disabled="disabled" selected="selected">Temas --</option>
-             <%= options_from_collection_for_select(ActsAsTaggableOn::Tag.all, :name, :name, prompt: 'Temas...') %>
+           <select class="js-order-selector" name="order-selector"> 
+             <%= available_options_for_order_selector(@valid_orders, @order) %>
            </select>
         </form>
-      <% end %>
+      </div>
+
     </div>
   </div>
-  <!-- /. Filter topic results -->
 
   <div class="row">
     <div id="debates" class="debates-list small-12 medium-9 column">

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -12,11 +12,23 @@
   <!-- Filter topic results -->
   <div class="filters row">
     <div class="small-12 column">
-      <h2>
-        <%= t("debates.index.filter_topic",
-        number: "N",
-        topic: "topic").html_safe %>
-      </h2>
+      <% if @tag_filter %>
+        <h2>
+          <%= t("debates.index.filter_topic",
+                 number: @debates.size,
+                 # TODO translation
+                 topic: @tag_filter).html_safe %>
+        </h2>
+      <% else %>
+        <h2>Filtrar por tema:  </h2>
+        <form class="inline-block">
+           <select class="js-tag-filter" name="tag-filter"> 
+             <%# select_tag 'tag-filter', nil, {prompt: 'Temas --', class: 'js-tag-filter'} do %>
+             <option value="default" disabled="disabled" selected="selected">Temas --</option>
+             <%= options_from_collection_for_select(ActsAsTaggableOn::Tag.all, :name, :name, prompt: 'Temas...') %>
+           </select>
+        </form>
+      <% end %>
     </div>
   </div>
   <!-- /. Filter topic results -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,11 +33,14 @@ en:
     index:
       create_debate: Create a debate
       showing: You are seeing debates
+      select_order: Order by 
       orders:
         created_at: newest
         total_votes: most voted
         likes: best rated
+      select_topic: "Filter by topic:"
       filter_topic: "You are seeing %{number} debates with the topic '%{topic}'"
+      all: All
     debate:
       debate: Debate
       comments:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,6 @@ en:
   debates:
     index:
       create_debate: Create a debate
-      showing: You are seeing debates
       select_order: Order by 
       orders:
         created_at: newest

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,7 +32,6 @@ es:
   debates:
     index:
       create_debate: Crea un debate
-      showing: "Estás viendo los debates"
       select_order: Ordenar por
       orders:
         created_at: "más nuevos"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -33,11 +33,14 @@ es:
     index:
       create_debate: Crea un debate
       showing: "Estás viendo los debates"
+      select_order: Ordenar por
       orders:
         created_at: "más nuevos"
         total_votes: "más votados"
         likes: mejor valorados
+      select_topic: "Filtrar por tema:"
       filter_topic: "Estás viendo %{number} debates con el tema '%{topic}'"
+      all: Todos
     debate:
       debate: Debate
       comments:

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -410,16 +410,15 @@ feature 'Debates' do
 
   feature 'Debates can be filtered by tags', :js do
     let!(:debate1) { create(:debate, tag_list: ["Deporte", "Corrupción"]) }
-    let!(:debate2) { create(:debate, tag_list: ["Deporte", "Corrupción", "Fiestas populares"]) }
+    let!(:debate2) { create(:debate, tag_list: ["Deporte", "Fiestas populares"]) }
     let!(:debate3) { create(:debate, tag_list: ["Corrupción", "Fiestas populares"]) }
 
     scenario 'By default no tag filter is applied' do
       visit debates_path
 
-      expect(page).to have_content('Filtrar por tema')
-      expect(page).not_to have_content('con el tema')
+      expect(page).to have_content('Filter by topic')
+      expect(page).not_to have_content('with the topic')
       expect(page).to have_selector('#debates .debate', count: 3)
-      expect(current_url).to_not include('tag=')
     end
 
     scenario 'Debates are filtered by single tag' do
@@ -427,17 +426,15 @@ feature 'Debates' do
 
       select('Deporte', from: 'tag-filter')
 
-      expect(page).not_to have_content('Filtrar por tema')
-      expect(page).to have_content('with the topic')
+      expect(page).not_to have_content('Filter by topic')
       expect(page).not_to have_select('tag-filter')
+      expect(page).to have_content('with the topic')
       expect(current_url).to include('tag=Deporte')
-      expect(page).to have_selector('#debates .debate', count: 2)
 
+      expect(page).to have_selector('#debates .debate', count: 2)
       expect(page).to_not have_content(debate3.title) 
       expect(page).to have_content(debate1.title) 
       expect(page).to have_content(debate2.title) 
     end
-
   end
-
 end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -407,4 +407,37 @@ feature 'Debates' do
       expect(@most_liked_debate.title).to appear_before(@most_voted_debate.title)
     end
   end
+
+  feature 'Debates can be filtered by tags', :js do
+    let!(:debate1) { create(:debate, tag_list: ["Deporte", "Corrupción"]) }
+    let!(:debate2) { create(:debate, tag_list: ["Deporte", "Corrupción", "Fiestas populares"]) }
+    let!(:debate3) { create(:debate, tag_list: ["Corrupción", "Fiestas populares"]) }
+
+    scenario 'By default no tag filter is applied' do
+      visit debates_path
+
+      expect(page).to have_content('Filtrar por tema')
+      expect(page).not_to have_content('con el tema')
+      expect(page).to have_selector('#debates .debate', count: 3)
+      expect(current_url).to_not include('tag=')
+    end
+
+    scenario 'Debates are filtered by single tag' do
+      visit debates_path
+
+      select('Deporte', from: 'tag-filter')
+
+      expect(page).not_to have_content('Filtrar por tema')
+      expect(page).to have_content('with the topic')
+      expect(page).not_to have_select('tag-filter')
+      expect(current_url).to include('tag=Deporte')
+      expect(page).to have_selector('#debates .debate', count: 2)
+
+      expect(page).to_not have_content(debate3.title) 
+      expect(page).to have_content(debate1.title) 
+      expect(page).to have_content(debate2.title) 
+    end
+
+  end
+
 end


### PR DESCRIPTION
Ya se pueden filtrar los debates por tema (solo un tema al mismo tiempo) y tambien elegir el orden (issue #193). De momento se ha quedado así, no sabía si meterme con los estilos:

![selection_026](https://cloud.githubusercontent.com/assets/7111622/9549904/b075cb04-4da8-11e5-99a8-1231714df16f.png)

![selection_027](https://cloud.githubusercontent.com/assets/7111622/9549914/b815294a-4da8-11e5-8fd3-4f037c352032.png)



