### PR TITLE
#225 : Tag cloud ordered by count and name

### DIFF
--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -8,6 +8,7 @@ class DebatesController < ApplicationController
   def index
     @debates = Debate.search(params).page(params[:page]).for_render.send("sort_by_#{@order}")
     @tags = ActsAsTaggableOn::Tag.all
+    @tag_cloud = Debate.tag_counts.order('count desc, name asc')
     set_debate_votes(@debates)
   end
 

--- a/app/views/shared/_tag_cloud.html.erb
+++ b/app/views/shared/_tag_cloud.html.erb
@@ -2,7 +2,7 @@
   <div class="sidebar-divider"></div>
   <h3><%= t("shared.tags_cloud.tags") %></h3>
   <br>
-  <% tag_cloud Debate.tag_counts, %w[s m l] do |tag, css_class| %>
+  <% tag_cloud Debate.tag_counts.order('count desc, name asc'), %w[s m l] do |tag, css_class| %>
     <%= link_to sanitize("#{tag.name} <span class='label round info'>#{tag.taggings_count}</span>"), debates_path(tag: tag.name), class: css_class %>
   <% end %>
 </div>

--- a/app/views/shared/_tag_cloud.html.erb
+++ b/app/views/shared/_tag_cloud.html.erb
@@ -2,7 +2,7 @@
   <div class="sidebar-divider"></div>
   <h3><%= t("shared.tags_cloud.tags") %></h3>
   <br>
-  <% tag_cloud Debate.tag_counts.order('count desc, name asc'), %w[s m l] do |tag, css_class| %>
+  <% tag_cloud @tag_cloud, %w[s m l] do |tag, css_class| %>
     <%= link_to sanitize("#{tag.name} <span class='label round info'>#{tag.taggings_count}</span>"), debates_path(tag: tag.name), class: css_class %>
   <% end %>
 </div>

--- a/spec/features/tags_spec.rb
+++ b/spec/features/tags_spec.rb
@@ -47,13 +47,17 @@ feature 'Tags' do
   scenario 'Tag Cloud' do
     1.times  { create(:debate, tag_list: 'Medio Ambiente') }
     5.times  { create(:debate, tag_list: 'Corrupción') }
+    5.times  { create(:debate, tag_list: 'Educación') }
     10.times { create(:debate, tag_list: 'Economía') }
 
     visit debates_path
 
-    within(:css, "#tag-cloud .s") { expect(page).to have_content('Medio Ambiente 1') }
-    within(:css, "#tag-cloud .m") { expect(page).to have_content('Corrupción 5') }
-    within(:css, "#tag-cloud .l") { expect(page).to have_content('Economía 10') }
+    within(:css, "#tag-cloud") do
+      expect(page.find("a:eq(1)")).to have_content("Economía 10")
+      expect(page.find("a:eq(2)")).to have_content("Corrupción 5")
+      expect(page.find("a:eq(3)")).to have_content("Educación 5")
+      expect(page.find("a:eq(4)")).to have_content("Medio Ambiente 1")
+    end
   end
 
   scenario 'Create' do


### PR DESCRIPTION
Tag cloud is now ordered by count desc + name asc.