### PR TITLE
Flag cache

### DIFF
--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -15,6 +15,8 @@ class DebatesController < ApplicationController
   def show
     set_debate_votes(@debate)
     @comments = @debate.root_comments.recent.page(params[:page]).for_render
+    all_comments = @debate.comment_threads
+    current_ability.flag_cache = Flag::Cache.new(current_user, all_comments)
   end
 
   def new

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -16,7 +16,7 @@ class DebatesController < ApplicationController
     set_debate_votes(@debate)
     @comments = @debate.root_comments.recent.page(params[:page]).for_render
     all_comments = @debate.comment_threads
-    current_ability.flag_cache = Flag::Cache.new(current_user, all_comments)
+    current_ability.flag_cache = Flag.build_cache(current_user, all_comments)
   end
 
   def new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -100,7 +100,7 @@ class Ability
   end
 
   def flagged?(flaggable)
-    is_flagged = flag_cache && flag_cache.flagged?(flaggable)
+    is_flagged = flag_cache && flag_cache[flaggable.id]
     is_flagged.nil? ? Flag.flagged?(@user, flaggable) : is_flagged
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -100,11 +100,8 @@ class Ability
   end
 
   def flagged?(flaggable)
-    if flag_cache && flag_cache.user == @user && flag_cache.knows?(flaggable)
-      flag_cache.flagged?(flaggable)
-    else
-      Flag.flagged?(@user, flaggable)
-    end
+    is_flagged = flag_cache && flag_cache.flagged?(flaggable)
+    is_flagged.nil? ? Flag.flagged?(@user, flaggable) : is_flagged
   end
 
 end

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -32,14 +32,27 @@ class Flag < ActiveRecord::Base
     def initialize(user, flaggables)
       @cache = {}
       flags = Flag.by_user_and_flaggables(user, flaggables)
+
+      # Fill up the "trues"
       flags.each do |flag|
         @cache[flag.flaggable_type] ||= {}
         @cache[flag.flaggable_type][flag.flaggable_id] = true
+      end
+
+      # Fill up the "falses"
+      flaggables.each do |flaggable|
+        type = flaggable.class.name
+        @cache[type] ||= {}
+        @cache[type][flaggable.id] = !! @cache[type][flaggable.id]
       end
     end
 
     def flagged?(flaggable)
       @cache[flaggable.class.name].to_h[flaggable.id]
+    end
+
+    def knows?(flaggable)
+      flagged?(flaggable) != nil
     end
   end
 

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -30,20 +30,12 @@ class Flag < ActiveRecord::Base
     !! by_user_and_flaggable(user, flaggable).try(:first)
   end
 
-  class Cache
-    attr_accessor :user
-
-    def initialize(user, flaggables)
-      @user = user
-      @cache = {}
-      flags = Flag.by_user_and_flaggables(user, flaggables)
-      flags.each{ |flag| @cache[flag.flaggable_id] = true }
-      flaggables.each{ |flaggable| @cache[flaggable.id] = !! @cache[flaggable.id] }
-    end
-
-    def flagged?(flaggable)
-      @cache[flaggable.id]
-    end
+  def self.build_cache(user, flaggables)
+    hash = {}
+    flags = Flag.by_user_and_flaggables(user, flaggables)
+    flags.each{ |flag| hash[flag.flaggable_id]= true }
+    flaggables.each{ |flaggable| hash[flaggable.id]= !! hash[flaggable.id] }
+    hash
   end
 
   class AlreadyFlaggedError < StandardError

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -29,7 +29,10 @@ class Flag < ActiveRecord::Base
   end
 
   class Cache
+    attr_accessor :user
+
     def initialize(user, flaggables)
+      @user = user
       @cache = {}
       flags = Flag.by_user_and_flaggables(user, flaggables)
 

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -89,6 +89,6 @@ class Flag < ActiveRecord::Base
         query_values << type << ids
       end
       query_string = "(flags.user_id = ?) AND (#{query_strings.join(' OR ')})"
-      [query_string, user.id] + query_values
+      [query_string, user.try(:id)] + query_values
     end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -213,14 +213,14 @@ describe Ability do
 
     it 'calls Flag.flagged? when the flag_cache is set, but it does not know the flaggable' do
       ability.flag_cache = double(:cache, user: user)
-      expect(ability.flag_cache).to receive(:flagged?).with(comment).and_return(nil)
+      expect(ability.flag_cache).to receive(:[]).with(comment.id).and_return(nil)
       expect(Flag).to receive(:flagged?).with(user, comment).and_return(false)
       ability.flagged?(comment)
     end
 
     it 'calls flag_cache.flagged? when the flag_cache is set and it knows the flaggable' do
       ability.flag_cache = double(:cache, user: user)
-      expect(ability.flag_cache).to receive(:flagged?).with(comment).and_return(true)
+      expect(ability.flag_cache).to receive(:[]).with(comment.id).and_return(true)
       expect(Flag).to_not receive(:flagged?)
       ability.flagged?(comment)
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -205,30 +205,24 @@ describe Ability do
   describe '#flagged?' do
     let(:user) { create(:user) }
     let(:comment) { create(:comment) }
+
     it 'calls Flag.flagged? when the flag_cache is not set' do
       expect(Flag).to receive(:flagged?).with(user, comment).and_return(false)
-      expect(ability.flagged?(comment)).to_not be
-    end
-
-    it 'calls Flag.flagged? when the flag_cache is set but its user is different' do
-      ability.flag_cache = double(:cache, user: create(:user))
-      expect(Flag).to receive(:flagged?).with(user, comment).and_return(false)
-      expect(ability.flagged?(comment)).to_not be
+      ability.flagged?(comment)
     end
 
     it 'calls Flag.flagged? when the flag_cache is set, but it does not know the flaggable' do
       ability.flag_cache = double(:cache, user: user)
-      expect(ability.flag_cache).to receive(:knows?).with(comment).and_return(false)
+      expect(ability.flag_cache).to receive(:flagged?).with(comment).and_return(nil)
       expect(Flag).to receive(:flagged?).with(user, comment).and_return(false)
-      expect(ability.flagged?(comment)).to_not be
+      ability.flagged?(comment)
     end
 
-    it 'calls flag_cache.flagged? when the flag_cache is set, the user is correct, and it knows the flaggable' do
+    it 'calls flag_cache.flagged? when the flag_cache is set and it knows the flaggable' do
       ability.flag_cache = double(:cache, user: user)
-      expect(ability.flag_cache).to receive(:knows?).with(comment).and_return(true)
-      expect(ability.flag_cache).to receive(:flagged?).with(comment).and_return(false)
+      expect(ability.flag_cache).to receive(:flagged?).with(comment).and_return(true)
       expect(Flag).to_not receive(:flagged?)
-      expect(ability.flagged?(comment)).to_not be
+      ability.flagged?(comment)
     end
   end
 end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -53,32 +53,26 @@ describe Flag do
     end
   end
 
-  describe Flag::Cache do
+  describe '.create_cache' do
     let(:user) { create(:user) }
     let(:debate1) { create(:debate) }
     let(:debate2) { create(:debate) }
 
-    it 'accepts a user and a collection of flaggables' do
-      expect{ Flag::Cache.new(user, [debate2, debate1]) }.to_not raise_error
+    it 'accepts a user & collection of flaggables' do
+      expect{ Flag.build_cache(user, [debate2, debate1]) }.to_not raise_error
     end
 
-    describe '#flagged?' do
-      it 'returns false if the item was not flagged by the user' do
-        cache = Flag::Cache.new(user, [debate1, debate2])
-        expect(cache.flagged?(debate1)).to eq(false)
-      end
+    it 'returns nil if the item was not used for building the cache' do
+      cache = Flag.build_cache(user, [debate2])
+      expect(cache[debate1.id]).to eq(nil)
+    end
 
-      it 'returns true if the item was flagged by the user' do
-        Flag.flag!(user, debate1)
-        cache = Flag::Cache.new(user, [debate1, debate2])
-        expect(cache.flagged?(debate1)).to eq(true)
-        expect(cache.flagged?(debate2)).to eq(false)
-      end
-
-      it 'returns nil if the item was not used for building the cache' do
-        cache = Flag::Cache.new(user, [debate2])
-        expect(cache.flagged?(debate1)).to eq(nil)
-      end
+    it 'returns true if the item was flagged by the user, false if not' do
+      Flag.flag!(user, debate1)
+      cache = Flag.build_cache(user, [debate1, debate2])
+      expect(cache[debate1.id]).to eq(true)
+      expect(cache[debate2.id]).to eq(false)
     end
   end
+
 end


### PR DESCRIPTION
Añade una clase llamada Flag::Cache para reducir el número de requests a la base de datos debido al uso de flags.

También crea una de esas cachés y se la añade a la ability en el controller de Debates

Related with #228