### PR TITLE
Disallow votes from organizations

### DIFF
--- a/app/assets/javascripts/votes.js.coffee
+++ b/app/assets/javascripts/votes.js.coffee
@@ -3,9 +3,11 @@ App.Votes =
   hoverize: (votes) ->
     $(votes).hover ->
       $("div.anonymous-votes", votes).show();
+      $("div.organizations-votes", votes).show();
       $("div.not-logged", votes).show();
     , ->
       $("div.anonymous-votes", votes).hide();
+      $("div.organizations-votes", votes).hide();
       $("div.not-logged", votes).hide();
 
   initialize: ->

--- a/app/assets/stylesheets/debates.scss
+++ b/app/assets/stylesheets/debates.scss
@@ -135,7 +135,7 @@
     }
   }
 
-  .anonymous-votes {
+  .anonymous-votes, .organizations-votes {
     background: $warning-bg;
     color: $warning-color;
     height: 100%;
@@ -380,7 +380,7 @@
       padding-top: rem-calc(36);
     }
 
-    .anonymous-votes {
+    .anonymous-votes, .organizations-votes {
       padding-top: rem-calc(24);
     }
   }

--- a/app/helpers/cache_keys_helper.rb
+++ b/app/helpers/cache_keys_helper.rb
@@ -1,16 +1,20 @@
 module CacheKeysHelper
   def locale_and_user_status
     @cache_key_user ||= calculate_user_status
-    "#{I18n.locale}/user:#{@cache_key_user}"
+    "#{I18n.locale}/#{@cache_key_user}"
   end
 
   def calculate_user_status
-    user_status = if user_signed_in? && current_user.verified_at.present?
-      "verified"
-    elsif user_signed_in?
-      "signed"
+    user_status = "user"
+
+    if user_signed_in?
+      user_status += ":signed"
+      user_status += ":verified" if current_user.verified_at.present?
+      user_status += ":org" if current_user.organization?
     else
-      "visitor"
+      user_status += ":visitor"
     end
+
+    user_status
   end
 end

--- a/app/views/comments/_votes.html.erb
+++ b/app/views/comments/_votes.html.erb
@@ -3,17 +3,25 @@
 </span>
 &nbsp;|&nbsp;
 <span class="in_favor">
-  <%= link_to vote_comment_path(comment, value: 'yes'),
-      method: "post", remote: true do %>
-      <i class="icon-angle-up"></i>
+  <% if can?(:vote, comment) %>
+    <%= link_to vote_comment_path(comment, value: 'yes'),
+        method: "post", remote: true do %>
+        <i class="icon-angle-up"></i>
+    <% end %>
+  <% else %>
+    <i class="icon-angle-up"></i>
   <% end %>
   <%= comment.total_likes %>
 </span>
 
 <span class="against">
-  <%= link_to vote_comment_path(comment, value: 'no'),
-      method: "post", remote: true do %>
-      <i class="icon-angle-down"></i>
+  <% if can?(:vote, comment) %>
+    <%= link_to vote_comment_path(comment, value: 'no'),
+        method: "post", remote: true do %>
+        <i class="icon-angle-down"></i>
+    <% end %>
+  <% else %>
+    <i class="icon-angle-down"></i>
   <% end %>
   <%= comment.total_dislikes %>
 </span>

--- a/app/views/debates/_votes.html.erb
+++ b/app/views/debates/_votes.html.erb
@@ -21,7 +21,13 @@
     <%= t("debates.debate.votes", count: debate.total_votes) %>
   </span>
 
-  <% if user_signed_in? && current_user.unverified? && !debate.votable_by?(current_user)%>
+  <% if user_signed_in? && current_user.organization? %>
+  <div class="organizations-votes" style='display:none'>
+    <p>
+      <%= t("votes.organizations") %>
+    </p>
+  </div>
+  <% elsif user_signed_in? && current_user.unverified? && !debate.votable_by?(current_user)%>
   <div class="anonymous-votes" style='display:none'>
     <p>
       <%= t("votes.anonymous",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
     signup: sign up
     anonymous: "This debate already has too much anonymous votes, %{verify_account} to vote."
     verify_account: verify your account
+    organizations: Organizations can not vote
   account:
     show:
       title: "My account"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -146,6 +146,7 @@ es:
     signup: registrarte
     anonymous: "Este debate ya tiene demasiados votos anónimos, para poder votar %{verify_account}."
     verify_account: verifica tu cuenta
+    organizations: Las organizaciones no pueden votar
   account:
     show:
       title: "Mi cuenta"


### PR DESCRIPTION
Right now organizations are not allowed to vote debates or comments but the interface does not change for them.
This PR removes voting buttons/links from the organizations interface.