### PR TITLE
Filter dry 282

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -1,11 +1,11 @@
 class Admin::CommentsController < Admin::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+
+  has_filters %w{all with_confirmed_hide}
 
   before_filter :load_comment, only: [:confirm_hide, :restore]
 
   def index
-    @comments = Comment.only_hidden.send(@filter).page(params[:page])
+    @comments = Comment.only_hidden.send(@current_filter).page(params[:page])
   end
 
   def confirm_hide
@@ -21,15 +21,6 @@ class Admin::CommentsController < Admin::BaseController
   private
     def load_comment
       @comment = Comment.with_hidden.find(params[:id])
-    end
-
-    def set_valid_filters
-      @valid_filters = %w{all with_confirmed_hide}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
     end
 
 end

--- a/app/controllers/admin/debates_controller.rb
+++ b/app/controllers/admin/debates_controller.rb
@@ -1,11 +1,10 @@
 class Admin::DebatesController < Admin::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+  has_filters %w{all with_confirmed_hide}, only: :index
 
   before_filter :load_debate, only: [:confirm_hide, :restore]
 
   def index
-    @debates = Debate.only_hidden.send(@filter).page(params[:page])
+    @debates = Debate.only_hidden.send(@current_filter).page(params[:page])
   end
 
   def confirm_hide
@@ -22,15 +21,6 @@ class Admin::DebatesController < Admin::BaseController
 
     def load_debate
       @debate = Debate.with_hidden.find(params[:id])
-    end
-
-    def set_valid_filters
-      @valid_filters = %w{all with_confirmed_hide}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
     end
 
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,11 +1,11 @@
 class Admin::OrganizationsController < Admin::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+
+  has_filters %w{all pending verified rejected}, only: :index
 
   load_and_authorize_resource except: :search
 
   def index
-    @organizations = @organizations.send(@filter)
+    @organizations = @organizations.send(@current_filter)
     @organizations = @organizations.includes(:user).order(:name, 'users.email').page(params[:page])
   end
 
@@ -22,15 +22,5 @@ class Admin::OrganizationsController < Admin::BaseController
     @organization.reject
     redirect_to request.query_parameters.merge(action: :index)
   end
-
-  private
-    def set_valid_filters
-      @valid_filters = %w{all pending verified rejected}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
-    end
 
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,11 +1,11 @@
 class Admin::UsersController < Admin::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+
+  has_filters %w{all with_confirmed_hide}, only: :index
 
   before_filter :load_user, only: [:confirm_hide, :restore]
 
   def index
-    @users = User.only_hidden.send(@filter).page(params[:page])
+    @users = User.only_hidden.send(@current_filter).page(params[:page])
   end
 
   def show
@@ -28,15 +28,6 @@ class Admin::UsersController < Admin::BaseController
 
     def load_user
       @user = User.with_hidden.find(params[:id])
-    end
-
-    def set_valid_filters
-      @valid_filters = %w{all with_confirmed_hide}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
     end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 require "application_responder"
 
 class ApplicationController < ActionController::Base
+  include HasFilters
+
   before_filter :authenticate_http_basic
 
   before_filter :authenticate_user!, unless: :devise_controller?, if: :beta_site?

--- a/app/controllers/concerns/has_filters.rb
+++ b/app/controllers/concerns/has_filters.rb
@@ -1,0 +1,13 @@
+module HasFilters
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def has_filters(valid_filters, *args)
+      before_filter(*args) do
+        @valid_filters = valid_filters
+        @current_filter = params[:filter]
+        @current_filter = @valid_filters.first unless @valid_filters.include?(@current_filter)
+      end
+    end
+  end
+end

--- a/app/controllers/moderation/comments_controller.rb
+++ b/app/controllers/moderation/comments_controller.rb
@@ -1,12 +1,12 @@
 class Moderation::CommentsController < Moderation::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+
+  has_filters %w{all pending_flag_review with_ignored_flag}, only: :index
   before_filter :load_comments, only: :index
 
   load_and_authorize_resource
 
   def index
-    @comments = @comments.send(@filter)
+    @comments = @comments.send(@current_filter)
     @comments = @comments.page(params[:page])
   end
 
@@ -28,15 +28,6 @@ class Moderation::CommentsController < Moderation::BaseController
 
     def load_comments
       @comments = Comment.accessible_by(current_ability, :hide).flagged.sorted_for_moderation.includes(:commentable)
-    end
-
-    def set_valid_filters
-      @valid_filters = %w{all pending_flag_review with_ignored_flag}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
     end
 
 end

--- a/app/controllers/moderation/debates_controller.rb
+++ b/app/controllers/moderation/debates_controller.rb
@@ -1,13 +1,13 @@
 class Moderation::DebatesController < Moderation::BaseController
-  before_filter :set_valid_filters, only: :index
-  before_filter :parse_filter, only: :index
+
+  has_filters %w{all pending_flag_review with_ignored_flag}, only: :index
+
   before_filter :load_debates, only: :index
 
   load_and_authorize_resource
 
   def index
-    @debates = @debates.send(@filter)
-    @debates = @debates.page(params[:page])
+    @debates = @debates.send(@current_filter).page(params[:page])
   end
 
   def hide
@@ -28,15 +28,6 @@ class Moderation::DebatesController < Moderation::BaseController
 
     def load_debates
       @debates = Debate.accessible_by(current_ability, :hide).flagged.sorted_for_moderation
-    end
-
-    def set_valid_filters
-      @valid_filters = %w{all pending_flag_review with_ignored_flag}
-    end
-
-    def parse_filter
-      @filter = params[:filter]
-      @filter = 'all' unless @valid_filters.include?(@filter)
     end
 
 end

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -1,17 +1,6 @@
 <h2><%= t("admin.comments.index.title") %></h2>
 
-<dl class="sub-nav">
-  <dt><%= t("admin.comments.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("admin.comments.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("admin.comments.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.comments.index" %>
 
 <h3><%= page_entries_info @comments %></h3>
 

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -4,7 +4,7 @@
   <dt><%= t("admin.comments.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("admin.comments.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("admin.comments.index.filters.#{filter}"),

--- a/app/views/admin/debates/index.html.erb
+++ b/app/views/admin/debates/index.html.erb
@@ -1,17 +1,6 @@
 <h2><%= t("admin.debates.index.title") %></h2>
 
-<dl class="sub-nav">
-  <dt><%= t("admin.debates.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("admin.debates.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("admin.debates.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.debates.index" %>
 
 <h3><%= page_entries_info @debates %></h3>
 

--- a/app/views/admin/debates/index.html.erb
+++ b/app/views/admin/debates/index.html.erb
@@ -4,7 +4,7 @@
   <dt><%= t("admin.debates.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("admin.debates.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("admin.debates.index.filters.#{filter}"),

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -17,7 +17,7 @@
   <dt><%= t("admin.organizations.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("admin.organizations.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("admin.organizations.index.filters.#{filter}"),

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -13,18 +13,7 @@
 <% end %>
 <!-- /. Search organizations -->
 
-<dl class="sub-nav">
-  <dt><%= t("admin.organizations.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("admin.organizations.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("admin.organizations.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.organizations.index" %>
 
 <h3><%= page_entries_info @organizations %></h3>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,17 +1,6 @@
 <h2><%= t("admin.users.index.title") %></h2>
 
-<dl class="sub-nav">
-  <dt><%= t("admin.users.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("admin.users.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("admin.users.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "admin.users.index" %>
 
 <h3><%= page_entries_info @users %></h3>
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,7 +4,7 @@
   <dt><%= t("admin.users.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("admin.users.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("admin.users.index.filters.#{filter}"),

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -1,17 +1,6 @@
 <h2><%= t("moderation.comments.index.title") %></h2>
 
-<dl class="sub-nav">
-  <dt><%= t("moderation.comments.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("moderation.comments.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("moderation.comments.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "moderation.comments.index" %>
 
 <h3><%= page_entries_info @comments %></h3>
 

--- a/app/views/moderation/comments/index.html.erb
+++ b/app/views/moderation/comments/index.html.erb
@@ -4,7 +4,7 @@
   <dt><%= t("moderation.comments.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("moderation.comments.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("moderation.comments.index.filters.#{filter}"),

--- a/app/views/moderation/debates/index.html.erb
+++ b/app/views/moderation/debates/index.html.erb
@@ -4,7 +4,7 @@
   <dt><%= t("moderation.debates.index.filter") %>:</dt>
 
   <% @valid_filters.each do |filter| %>
-    <% if @filter == filter %>
+    <% if @current_filter == filter %>
       <dd class="active"><%= t("moderation.debates.index.filters.#{filter}") %></dd>
     <% else %>
       <dd><%= link_to t("moderation.debates.index.filters.#{filter}"),

--- a/app/views/moderation/debates/index.html.erb
+++ b/app/views/moderation/debates/index.html.erb
@@ -1,17 +1,6 @@
 <h2><%= t("moderation.debates.index.title") %></h2>
 
-<dl class="sub-nav">
-  <dt><%= t("moderation.debates.index.filter") %>:</dt>
-
-  <% @valid_filters.each do |filter| %>
-    <% if @current_filter == filter %>
-      <dd class="active"><%= t("moderation.debates.index.filters.#{filter}") %></dd>
-    <% else %>
-      <dd><%= link_to t("moderation.debates.index.filters.#{filter}"),
-        current_path_with_query_params(filter: filter) %></dd>
-    <% end %>
-  <% end %>
-</dl>
+<%= render 'shared/filter_subnav', i18n_namespace: "moderation.debates.index" %>
 
 <h3><%= page_entries_info @debates %></h3>
 

--- a/app/views/shared/_filter_subnav.html.erb
+++ b/app/views/shared/_filter_subnav.html.erb
@@ -1,0 +1,17 @@
+<% # Params:
+   #
+   #   i18n_namespace: for example "moderation.debates.index"
+%>
+
+<dl class="sub-nav">
+  <dt><%= t("#{i18n_namespace}.filter") %>: </dt>
+
+  <% @valid_filters.each do |filter| %>
+    <% if @current_filter == filter %>
+      <dd class="active"><%= t("#{i18n_namespace}.filters.#{filter}") %></dd>
+    <% else %>
+      <dd><%= link_to t("#{i18n_namespace}.filters.#{filter}"),
+        current_path_with_query_params(filter: filter) %></dd>
+    <% end %>
+  <% end %>
+</dl>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -99,13 +99,18 @@ ignore_missing:
 ignore_unused:
   - 'activerecord.*'
   - 'activemodel.*'
-  - 'admin.organizations.index.filter.*'
   - 'unauthorized.*'
   - 'simple_captcha.*'
   - 'admin.officials.level_*'
+  - 'admin.comments.index.filter*'
+  - 'admin.debates.index.filter*'
+  - 'admin.organizations.index.filter*'
+  - 'admin.users.index.filter*'
+  - 'moderation.comments.index.filter*'
+  - 'moderation.debates.index.filter*'
+  - 'debates.index.orders.*'
   - 'helpers.page_entries_info.*' # kaminari
   - 'views.pagination.*' # kaminari
-  - 'debates.index.orders.*' #order filters for debates
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/spec/controllers/concerns/has_filters_spec.rb
+++ b/spec/controllers/concerns/has_filters_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'HasFilters' do
+
+  class FakeController < ActionController::Base; end
+
+  controller(FakeController) do
+    include HasFilters
+    has_filters ['all', 'pending', 'reviewed'], only: :index
+
+    def index
+      render text: "#{@current_filter} (#{@valid_filters.join(' ')})"
+    end
+  end
+
+  it "has the valid filters set up" do
+    get :index
+    expect(response.body).to eq('all (all pending reviewed)')
+  end
+
+  describe "the current filter" do
+    it "defaults to the first one on the list" do
+      get :index
+      expect(response.body).to eq('all (all pending reviewed)')
+    end
+
+    it "can be changed by the filter param" do
+      get :index, filter: 'pending'
+      expect(response.body).to eq('pending (all pending reviewed)')
+    end
+
+    it "defaults to the first one on the list if given a bogus filter" do
+      get :index, filter: 'foobar'
+      expect(response.body).to eq('all (all pending reviewed)')
+    end
+  end
+end


### PR DESCRIPTION
Esta pull request elimina código repetido en la generación y renderizado de filtros en varios controllers y vistas.

He examinado los “selectores de orden” y de momento solamente aparecen en 1 sitio. Cuando haya más de 1, podremos ver cómo abstraer eso.

Fixes #282