### PR TITLE
Remove tag filter 337

### DIFF
--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -85,8 +85,9 @@ class DebatesController < ApplicationController
     end
 
     def parse_tag_filter
-      valid_tags = ActsAsTaggableOn::Tag.all.map(&:name)
-      @tag_filter = params[:tag] if valid_tags.include?(params[:tag])
+      if params[:tag].present?
+        @tag_filter = params[:tag] if ActsAsTaggableOn::Tag.where(name: params[:tag]).exists?
+      end
     end
 
 end

--- a/app/controllers/debates_controller.rb
+++ b/app/controllers/debates_controller.rb
@@ -1,13 +1,15 @@
 class DebatesController < ApplicationController
-  before_action :parse_order, :parse_tag_filter, only: :index
+  before_action :parse_order, only: :index
+  before_action :parse_tag_filter, only: :index
   before_action :authenticate_user!, except: [:index, :show]
 
   load_and_authorize_resource
   respond_to :html, :js
 
   def index
-    @debates = Debate.search(params).page(params[:page]).for_render.send("sort_by_#{@order}")
-    @tags = ActsAsTaggableOn::Tag.all
+    @debates = Debate.all
+    @debates = @debates.tagged_with(@tag_filter) if @tag_filter
+    @debates = @debates.page(params[:page]).for_render.send("sort_by_#{@order}")
     @tag_cloud = Debate.tag_counts.order('count desc, name asc')
     set_debate_votes(@debates)
   end

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -35,14 +35,6 @@ class Debate < ActiveRecord::Base
   # Ahoy setup
   visitable # Ahoy will automatically assign visit_id on create
 
-  def self.search(params)
-    if params[:tag]
-      tagged_with(params[:tag])
-    else
-      all
-    end
-  end
-
   def likes
     cached_votes_up
   end

--- a/app/views/debates/index.html.erb
+++ b/app/views/debates/index.html.erb
@@ -3,30 +3,24 @@
   <div class="filters row">
     <div class="small-9 column">
 
-      <div class="inline-block" >
-        <% if @tag_filter %>
-          <h2>
-            <%= t("debates.index.filter_topic",
-                   number: @debates.size,
-                   topic: @tag_filter) %>
-          </h2>
-        <% else %>
-          <h2><%= t("debates.index.select_topic") %></h2>
-          <form class="inline-block">
-             <select class="js-location-changer" name="tag-filter">
-               <option value="/" selected="selected"><%= t("debates.index.all") %></option>
-               <% @tags.each do |tag| %>
-                 <option value='<%= current_path_with_query_params(tag: tag.name) %>'>
-                   <%= tag.name %>
-                 </option>
-               <% end %>
-             </select>
-          </form>
-        <% end %>
-      </div>
+      <% if @tag_filter %>
+        <div class="inline-block small-8" >
+            <h2>
+              <%= t("debates.index.filter_topic",
+                     count: @debates.size,
+                     topic: @tag_filter) %>
+            </h2>
+        </div>
+      <% end %>
 
-      <div class="inline-block right">
-        <h6 class="inline-block"><%= t("debates.index.select_order") %></h6>
+      <div class="inline-block <%= 'right' if @tag_filter %>">
+        <h6 class="inline-block">
+          <% if @tag_filter %>
+            <%= t("debates.index.select_order") %>
+          <% else %>
+            <%= t("debates.index.select_order_long") %>
+          <% end %>
+        </h6>
         <form class="inline-block">
            <select class="js-location-changer" name="order-selector">
              <% @valid_orders.each do |order| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,13 +62,14 @@ en:
     index:
       create_debate: Create a debate
       select_order: Order by
+      select_order_long: Order debates by
       orders:
         created_at: newest
         total_votes: most voted
         likes: best rated
-      select_topic: "Filter by topic:"
-      filter_topic: "You are seeing %{number} debates with the topic '%{topic}'"
-      all: All
+      filter_topic:
+        one: "You are seeing one debate with the topic '%{topic}'"
+        other: "You are seeing %{count} debates with the topic '%{topic}'"
     debate:
       debate: Debate
       comments:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -62,13 +62,14 @@ es:
     index:
       create_debate: Crea un debate
       select_order: Ordenar por
+      select_order_long: Estás viendo los debates
       orders:
         created_at: "más nuevos"
         total_votes: "más votados"
-        likes: mejor valorados
-      select_topic: "Filtrar por tema:"
-      filter_topic: "Estás viendo %{number} debates con el tema '%{topic}'"
-      all: Todos
+        likes: "mejor valorados"
+      filter_topic:
+        one: "Estás viendo un debate con el tema ''%{topic}''"
+        other: "Estás viendo %{count} debates con el tema '%{topic}'"
     debate:
       debate: Debate
       comments:

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -407,34 +407,4 @@ feature 'Debates' do
       expect(@most_liked_debate.title).to appear_before(@most_voted_debate.title)
     end
   end
-
-  feature 'Debates can be filtered by tags', :js do
-    let!(:debate1) { create(:debate, tag_list: ["Deporte", "Corrupción"]) }
-    let!(:debate2) { create(:debate, tag_list: ["Deporte", "Fiestas populares"]) }
-    let!(:debate3) { create(:debate, tag_list: ["Corrupción", "Fiestas populares"]) }
-
-    scenario 'By default no tag filter is applied' do
-      visit debates_path
-
-      expect(page).to have_content('Filter by topic')
-      expect(page).not_to have_content('with the topic')
-      expect(page).to have_selector('#debates .debate', count: 3)
-    end
-
-    scenario 'Debates are filtered by single tag' do
-      visit debates_path
-
-      select('Deporte', from: 'tag-filter')
-
-      expect(page).not_to have_content('Filter by topic')
-      expect(page).not_to have_select('tag-filter')
-      expect(page).to have_content('with the topic')
-      expect(current_url).to include('tag=Deporte')
-
-      expect(page).to have_selector('#debates .debate', count: 2)
-      expect(page).to_not have_content(debate3.title)
-      expect(page).to have_content(debate1.title)
-      expect(page).to have_content(debate2.title)
-    end
-  end
 end

--- a/spec/models/debate_spec.rb
+++ b/spec/models/debate_spec.rb
@@ -174,21 +174,6 @@ describe Debate do
     end
   end
 
-  describe "#search" do
-    let!(:economy) { create(:debate, tag_list: "Economy") }
-    let!(:health)  { create(:debate, tag_list: "Health")  }
-
-    it "returns debates tagged with params tag" do
-      params = {tag: "Economy"}
-      expect(Debate.search(params)).to match_array([economy])
-    end
-
-    it "returns all debates if no parameters" do
-      params = {}
-      expect(Debate.search(params)).to match_array([economy, health])
-    end
-  end
-
   describe '#default_order' do
     let!(:economy) { create(:debate) }
     let!(:health)  { create(:debate) }


### PR DESCRIPTION
Fixes #337, and also makes a couple small refactoring / improvements:

* Faster tag checking (“1 ‘exists’ request sometimes” instead of “load all tags always”)
* Better i18n errors (pluralization “one debate”, “2 debates”)