### PR TITLE
Removes language switcher if only one locale

### DIFF
--- a/app/views/shared/_locale_switcher.html.erb
+++ b/app/views/shared/_locale_switcher.html.erb
@@ -1,16 +1,18 @@
-<div class="locale">
-  <span class="inline-block">
-    <i class="icon-language"></i>
-    <%= t("layouts.header.locale") %>
-  </span>
-  <form class="locale-form">
-    <select class="js-location-changer locale-switcher" name="locale-switcher">
-      <% I18n.available_locales.map do |loc| %>
-        <option <%= 'selected' if loc == I18n.locale %>
-                value='<%= current_path_with_query_params(locale: loc) %>'>
-          <%= I18n.t('locale', locale: loc) %>
-        </option>
-      <% end %>
-    </select>
-  </form>
-</div>
+<% if I18n.available_locales.size > 1 %>
+  <div class="locale">
+    <span class="inline-block">
+      <i class="icon-language"></i>
+      <%= t("layouts.header.locale") %>
+    </span>
+    <form class="locale-form">
+      <select class="js-location-changer locale-switcher" name="locale-switcher">
+        <% I18n.available_locales.map do |loc| %>
+          <option <%= "selected" if loc == I18n.locale %>
+                  value="<%= current_path_with_query_params(locale: loc) %>">
+            <%= I18n.t("locale", locale: loc) %>
+          </option>
+        <% end %>
+      </select>
+    </form>
+  </div>
+<% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.i18n.available_locales = [:es]
 end

--- a/spec/features/localization_spec.rb
+++ b/spec/features/localization_spec.rb
@@ -32,4 +32,15 @@ feature 'Localization' do
     expect(page).to_not have_content('Language')
     expect(page).to have_select('locale-switcher', selected: 'Español')
   end
+
+  scenario 'Locale switcher not present if only one locale' do
+    initial_locales = I18n.available_locales
+    I18n.available_locales = [:en]
+
+    visit '/'
+    expect(page).to_not have_content('Language')
+    expect(page).to_not have_css('div.locale')
+
+    I18n.available_locales = initial_locales
+  end
 end


### PR DESCRIPTION
and disables :en in production

Closes #342 