### PR TITLE
bugfix: adds cache for authors of debate/comment

### DIFF
--- a/app/helpers/cache_keys_helper.rb
+++ b/app/helpers/cache_keys_helper.rb
@@ -1,11 +1,11 @@
 module CacheKeysHelper
 
-  def locale_and_user_status
-    @cache_key_user ||= calculate_user_status
+  def locale_and_user_status(authorable=nil)
+    @cache_key_user ||= calculate_user_status(authorable)
     "#{I18n.locale}/#{@cache_key_user}"
   end
 
-  def calculate_user_status
+  def calculate_user_status(authorable=nil)
     user_status = "user"
 
     if user_signed_in?
@@ -14,6 +14,7 @@ module CacheKeysHelper
       user_status += ":org" if current_user.organization?
       user_status += ":admin" if current_user.administrator?
       user_status += ":moderator" if current_user.moderator?
+      user_status += ":author" if authorable && authorable.author == current_user
     else
       user_status += ":visitor"
     end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<% cache [locale_and_user_status, comment, @commentable, comment.author, (@comment_flags[comment.id] if @comment_flags)] do %>
+<% cache [locale_and_user_status(comment), comment, @commentable, comment.author, (@comment_flags[comment.id] if @comment_flags)] do %>
   <div class="row">
   	<div id="<%= dom_id(comment) %>" class="comment small-12 column">
 

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -1,4 +1,4 @@
-<% cache [locale_and_user_status, @debate, @debate.author, Flag.flagged?(current_user, @debate)] do %>
+<% cache [locale_and_user_status(@debate), @debate, @debate.author, Flag.flagged?(current_user, @debate)] do %>
   <section class="debate-show">
     <div id="<%= dom_id(@debate) %>" class="row">
       <div class="small-12 medium-9 column">


### PR DESCRIPTION
se mostraba a veces el botón de 'editar debate' a usuarios que no eran el autor. Aunque al pinchar no tenían permiso para editarlo, el botón no debería mostrarseles.
Esta PR añade info a la cache_key sobre si el current_user es el autor o no del debate/comentario.