### PR TITLE
refactors debate's tags related utility methods

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -86,13 +86,15 @@ class Debate < ActiveRecord::Base
   end
 
   def tag_list_with_limit(limit = nil)
-    tags.most_used(limit).pluck :name
+    return tags if limit.blank?
+
+    tags.sort{|a,b| b.taggings_count <=> a.taggings_count}[0, limit]
   end
 
   def tags_count_out_of_limit(limit = nil)
     return 0 unless limit
 
-    count = tags.count - limit
+    count = tags.size - limit
     count < 0 ? 0 : count
   end
 

--- a/app/views/shared/_tags.html.erb
+++ b/app/views/shared/_tags.html.erb
@@ -3,7 +3,7 @@
 <% if debate.tags.any? %>
   <span class='tags'>
     <% debate.tag_list_with_limit(limit).each do |tag| %>
-      <%= link_to sanitize(tag), debates_path(tag: tag) %>
+      <%= link_to sanitize(tag.name), debates_path(tag: tag.name) %>
     <% end %>
 
     <% if debate.tags_count_out_of_limit(limit) > 0 %>


### PR DESCRIPTION
When rendering the debates index list tags are already loaded. Using the preloaded array instead of extracting them again for each debate saves 50 query per index (2 query per debate in the page)