### PR TITLE
Changes views so that administrators can see the debate moderation actions

### DIFF
--- a/app/helpers/abilities_helper.rb
+++ b/app/helpers/abilities_helper.rb
@@ -1,7 +1,0 @@
-module AbilitiesHelper
-
-  def moderator?
-    current_user.try(:moderator?)
-  end
-
-end

--- a/app/views/debates/show.html.erb
+++ b/app/views/debates/show.html.erb
@@ -56,11 +56,9 @@
 
         <%= render 'shared/tags', debate: @debate %>
 
-        <% if moderator? %>
-          <div class='js-moderator-debate-actions'>
-            <%= render 'actions', debate: @debate %>
-          </div>
-        <% end %>
+        <div class='js-moderator-debate-actions'>
+          <%= render 'actions', debate: @debate %>
+        </div>
       </div>
 
       <aside class="small-12 medium-3 column">


### PR DESCRIPTION
Actualmente los administradores solamente pueden ver las acciones de moderación de los debates si son moderadores también. Las acciones de moderación ya tienen los links protegidos con un `can? :hide` así que se pueden renderizar siempre.