### PR TITLE
Deploy custom branch 357

### DIFF
--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-ask :branch, :master
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :preproduction
 set :rails_env, :preproduction

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+set :branch, 'master'
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :preproduction
 set :rails_env, :preproduction

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-set :branch, :master
+ask :branch, :master
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :preproduction
 set :rails_env, :preproduction

--- a/config/deploy/preproduction.rb
+++ b/config/deploy/preproduction.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-set :branch, 'master'
+set :branch, :master
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :preproduction
 set :rails_env, :preproduction

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-set :branch, ENV['branch'] || 'master'
+set :branch, ENV['branch'] || :master
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :staging
 set :rails_env, :staging

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-set :branch, :master
+ask :branch, :master
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :staging
 set :rails_env, :staging

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+set :branch, ENV['branch'] || 'master'
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :staging
 set :rails_env, :staging

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,7 +1,7 @@
 set :deploy_to, deploysecret(:deploy_to)
 set :server_name, deploysecret(:server_name)
 set :db_server, deploysecret(:db_server)
-ask :branch, :master
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 set :ssh_options, port: deploysecret(:ssh_port)
 set :stage, :staging
 set :rails_env, :staging


### PR DESCRIPTION
It asks for the branch to deploy when deploying to staging & preproduction. Defaults to the current branch.

Before:

```
(my-foo-branch)$ cap staging deploy
<deploy master to staging>
```

After

```
(my-foo-bar)$ cap staging deploy
Please enter branch (my-foo-bar):
<deploys the selected branch, or my-foo-bar if just pressed enter>
```

Fixes #357