### PR TITLE
Adds utf-8 cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'devise-async'
 gem 'newrelic_rpm'
+gem 'utf8-cleaner'
 
 gem 'ahoy_matey', '~> 1.2.1'
 gem 'groupdate'   # group temporary data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,6 +377,7 @@ GEM
       raindrops (~> 0.7)
     uniform_notifier (1.9.0)
     user_agent_parser (2.2.0)
+    utf8-cleaner (0.0.9)
     uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
@@ -454,6 +455,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   unicorn
+  utf8-cleaner
   web-console (~> 2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
Do not merge, needs a test.

Prevents 'Invalid byte sequence in UTF-8' by cleaning params up before
they reach the app with a rack middleware.
