### PR TITLE
Welcome screen

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,11 @@
+class Users::SessionsController < Devise::SessionsController
+
+  def after_sign_in_path_for(resource)
+    if resource.show_welcome_screen?
+      welcome_path
+    else
+      root_path
+    end
+  end
+
+end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,9 +1,14 @@
 class WelcomeController < ApplicationController
   skip_authorization_check
 
+  layout "devise", only: :welcome
+
   def index
     @featured_debates = Debate.sort_by_confidence_score.limit(3).for_render
     set_debate_votes(@featured_debates)
+  end
+
+  def welcome
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,4 +135,8 @@ class User < ActiveRecord::Base
       !!(unconfirmed_email && unconfirmed_email !~ OMNIAUTH_EMAIL_REGEX)
   end
 
+  def show_welcome_screen?
+    sign_in_count == 1 && unverified? && !organization
+  end
+
 end

--- a/app/views/welcome/welcome.html.erb
+++ b/app/views/welcome/welcome.html.erb
@@ -1,0 +1,13 @@
+<h2><%= t("welcome.welcome.title") %></h2>
+<p><%= t("welcome.welcome.instructions_1_html") %></p>
+<p><%= t("welcome.welcome.instructions_2_html") %></p>
+<p><%= t("welcome.welcome.instructions_3_html") %></p>
+<p>
+  <%= link_to t("welcome.welcome.verify_account"),
+      new_residence_path, class: "button large success radius margin-top expand" %>
+</p>
+<p class="text-center">
+  <%= link_to t("welcome.welcome.go_to_index"),
+      root_path, class: "small margin-top expand" %>
+</p>
+<p><%= t("welcome.welcome.instructions_4_html") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,14 @@ en:
       all: "You are not authorized to %{action} %{subject}."
   welcome:
     last_debates: Last debates
+    welcome:
+      title: Account verification
+      instructions_1_html: "Welcome to the public participation website."
+      instructions_2_html: "We have detected that <b>your email is confirmed but we were not able to verify your citizen data</b>."
+      instructions_3_html: "Without verifying them, <b>you have only partial access to the website</b>. You need to be verified, for example, in order to participate in public proposals."
+      verify_account: "Verify my account now"
+      go_to_index: "I prefer to continue as a non-verified user with limited access"
+      instructions_4_html: "If you want to verify your account later on, you can do so in <i>My account -> Verify my account</i>."
   omniauth:
     finish_signup:
       title: Add Email

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -213,6 +213,14 @@ es:
       all: "No tienes permiso para realizar la acción '%{action}' sobre %{subject}."
   welcome:
     last_debates: Últimos debates
+    welcome:
+      title: Verificación de cuenta
+      instructions_1_html: "Bienvenido a la página de participación ciudadana"
+      instructions_2_html: "Hemos detectado que <b>tu email está confirmada pero no hemos verificado tus datos todavía</b>."
+      instructions_3_html: "Sin verificar tus datos <b>el acceso que tienes es limitado</b>. Verificarlos ahora te permitirá, por ejemplo, apoyar propuestas ciudadanas."
+      verify_account: "Verificar mi cuenta"
+      go_to_index: "Quiero entrar como un usuario no verificado (acceso limitado)"
+      instructions_4_html: "Si quieres verificarte más tarde, puedes hacerlo en <i>Mi cuenta -> Verificar mi cuenta</i>."
   omniauth:
     finish_signup:
       title: Añade tu email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
   root 'welcome#index'
+  get '/welcome', to: 'welcome#welcome'
 
   resources :debates do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
                        registrations: 'users/registrations',
+                       sessions: 'users/sessions',
                        omniauth_callbacks: 'users/omniauth_callbacks'
                      }
   devise_for :organizations, class_name: 'User',
@@ -26,6 +27,7 @@ Rails.application.routes.draw do
   # You can have the root of your site routed with "root"
   root 'welcome#index'
   get '/welcome', to: 'welcome#welcome'
+
 
   resources :debates do
     member do

--- a/spec/features/welcome_spec.rb
+++ b/spec/features/welcome_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+feature "Welcome screen" do
+
+  scenario 'a regular users sees it the first time he logs in' do
+    user = create(:user)
+
+    login_through_form_as(user)
+
+    expect(current_path).to eq(welcome_path)
+  end
+
+  scenario 'it is not shown more than once' do
+    user = create(:user, sign_in_count: 2)
+
+    login_through_form_as(user)
+
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario 'is not shown to organizations' do
+    organization = create(:organization)
+
+    login_through_form_as(organization.user)
+
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario 'it is not shown to level-2 users' do
+    user = create(:user, residence_verified_at: Time.now, confirmed_phone: "123")
+
+    login_through_form_as(user)
+
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario 'it is not shown to level-3 users' do
+    user = create(:user, verified_at: Time.now)
+
+    login_through_form_as(user)
+
+    expect(current_path).to eq(root_path)
+  end
+
+end

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -14,6 +14,16 @@ module CommonActions
     click_button 'Sign up'
   end
 
+  def login_through_form_as(user)
+    visit root_path
+    click_link 'Log in'
+
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: user.password
+
+    click_button 'Log in'
+  end
+
   def confirm_email
     expect(page).to have_content "A message with a confirmation link has been sent to your email address."
 


### PR DESCRIPTION
Adds a welcome screen urging the users to verify their account.

The screen only appears:
* The first time the user logs in
* If the user is not an organization,
* And level1

![screen shot 2015-09-10 at 17 44 43](https://cloud.githubusercontent.com/assets/63131/9793034/afbd9378-57e3-11e5-9833-0d2b399ecd0c.png)


Fixes #308