### PR TITLE
Adds support for accented searches

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -138,7 +138,7 @@ class Debate < ActiveRecord::Base
   end
 
   def self.search(terms)
-    terms.present? ? where("title ILIKE ? OR description ILIKE ?", "%#{terms}%", "%#{terms}%") : none
+    terms.present? ? where("unaccent(title) ILIKE unaccent(?) OR unaccent(description) ILIKE unaccent(?)", "%#{terms}%", "%#{terms}%") : none
   end
 
   def conflictive?

--- a/db/migrate/20150910185110_add_unaccent_extension.rb
+++ b/db/migrate/20150910185110_add_unaccent_extension.rb
@@ -1,0 +1,9 @@
+class AddUnaccentExtension < ActiveRecord::Migration
+  def up
+    execute "CREATE EXTENSION IF NOT EXISTS unaccent"
+  end
+
+  def down
+    execute "DROP EXTENSION unaccent"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150910152734) do
+ActiveRecord::Schema.define(version: 20150910185110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "addresses", force: :cascade do |t|
     t.integer  "user_id"
@@ -258,6 +259,7 @@ ActiveRecord::Schema.define(version: 20150910152734) do
     t.datetime "letter_requested_at"
     t.datetime "confirmed_hide_at"
     t.string   "letter_verification_code"
+    t.integer  "letter_verification_tries",               default: 0
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -439,10 +439,10 @@ feature 'Debates' do
     debate1 = create(:debate, title: "Show me what you got")
     debate2 = create(:debate, title: "Get Schwifty")
     debate3 = create(:debate)
-    debate4 = create(:debate, description: "Schwifty in here")
+    debate4 = create(:debate, description: "Schwíftÿ in here")
 
     visit debates_path
-    fill_in "search", with: "Schwifty"
+    fill_in "search", with: "Schwìfty"
     click_button "Search"
 
     within("#debates") do


### PR DESCRIPTION
Fixes #418 

Ya podemos buscar *Tetuán*, *Tetuan* y hasta *Têtüàn*, que la búsqueda devolverá debates con alguna variante en su contenido. 