### PR TITLE
Añadido :terms_of_service a User::first_or_create_for_oauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,8 @@ class User < ActiveRecord::Base
       user = User.new(
         username: auth.info.nickname || auth.extra.raw_info.name.parameterize('-') || auth.uid,
         email: email ? email : "#{OMNIAUTH_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com",
-        password: Devise.friendly_token[0,20]
+        password: Devise.friendly_token[0,20],
+        terms_of_service: '1'
       )
       user.skip_confirmation!
       user.save!

--- a/app/views/devise/_omniauth_form.html.erb
+++ b/app/views/devise/_omniauth_form.html.erb
@@ -7,5 +7,6 @@
   <%= link_to t("omniauth.twitter.sign_up"), user_omniauth_authorize_path(:twitter), class: "button-twitter button radius expand" %>
   <%= link_to t("omniauth.facebook.sign_up"), user_omniauth_authorize_path(:facebook), class: "button-facebook button radius expand" %>
   <%= link_to t("omniauth.google_oauth2.sign_up"), user_omniauth_authorize_path(:google_oauth2), class: "button-google button radius expand" %>
+  <p>Al hacer login con una red social, usted está aceptando los términos legales.</p>
   <hr/>
 <% end %>

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -45,7 +45,7 @@ feature 'Users' do
     end
   end
 
-  xcontext 'OAuth authentication' do
+  context 'OAuth authentication' do
     context 'Twitter' do
       background do
         #request.env["devise.mapping"] = Devise.mappings[:user]

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -45,7 +45,7 @@ feature 'Users' do
     end
   end
 
-  context 'OAuth authentication' do
+  xcontext 'OAuth authentication' do
     context 'Twitter' do
       background do
         #request.env["devise.mapping"] = Devise.mappings[:user]


### PR DESCRIPTION
Cuando un usuario se crea mediante `User::first_or_create_for_oauth` no se incluye el atributo `terms_of_service` en la creación de usuario. Esto da un error, ya que en nuestra clase `User` tenemos: 
 ```ruby
 validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
```

He intentado buscar alguna manera de esquivar esta validación sólo para este método, pero no he encontrado nada elegante. Si tenéis otra alternativa mejor, por favor decídmelo.

Por otra parte he encontrado que el test correspondiente al sign up con Omniauth pasa después de esta pequeña modificación. Actualmente el test está 'pendiente', a la espera, me imagino, de que se active la autenticación.