### PR TITLE
Incluyendo etiquetas en el buscador de debates 

### DIFF
--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -116,8 +116,10 @@ class Debate < ActiveRecord::Base
   def self.search(terms)
     return none unless terms.present?
 
-    ids = where("debates.title ILIKE ? OR debates.description ILIKE ?", "%#{terms}%", "%#{terms}%").pluck(:id) | tagged_with(terms).pluck(:id)
-    where(id: ids)
+    debate_ids = where("debates.title ILIKE ? OR debates.description ILIKE ?",
+                       "%#{terms}%", "%#{terms}%").pluck(:id)
+    tag_ids = tagged_with(terms, wild: true, any: true).pluck(:id)
+    where(id: [debate_ids, tag_ids].flatten.compact)
   end
 
   def conflictive?

--- a/app/models/debate.rb
+++ b/app/models/debate.rb
@@ -114,7 +114,10 @@ class Debate < ActiveRecord::Base
   end
 
   def self.search(terms)
-    terms.present? ? where("title ILIKE ? OR description ILIKE ?", "%#{terms}%", "%#{terms}%") : none
+    return none unless terms.present?
+
+    ids = where("debates.title ILIKE ? OR debates.description ILIKE ?", "%#{terms}%", "%#{terms}%").pluck(:id) | tagged_with(terms).pluck(:id)
+    where(id: ids)
   end
 
   def conflictive?

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -483,16 +483,18 @@ feature 'Debates' do
     debate3 = create(:debate)
     debate4 = create(:debate, description: "Schwifty in here")
     debate5 = create(:debate, tag_list: 'schwifty')
+    debate6 = create(:debate, tag_list: ['awesome foreign schwifty', 'major'])
 
     visit debates_path
     fill_in "search", with: "Schwifty"
     click_button "Search"
 
     within("#debates") do
-      expect(page).to have_css('.debate', count: 3)
+      expect(page).to have_css('.debate', count: 4)
       expect(page).to have_content(debate2.title)
       expect(page).to have_content(debate4.title)
       expect(page).to have_content(debate5.title)
+      expect(page).to have_content(debate6.title)
       expect(page).to_not have_content(debate1.title)
       expect(page).to_not have_content(debate3.title)
     end

--- a/spec/features/debates_spec.rb
+++ b/spec/features/debates_spec.rb
@@ -482,15 +482,17 @@ feature 'Debates' do
     debate2 = create(:debate, title: "Get Schwifty")
     debate3 = create(:debate)
     debate4 = create(:debate, description: "Schwifty in here")
+    debate5 = create(:debate, tag_list: 'schwifty')
 
     visit debates_path
     fill_in "search", with: "Schwifty"
     click_button "Search"
 
     within("#debates") do
-      expect(page).to have_css('.debate', count: 2)
+      expect(page).to have_css('.debate', count: 3)
       expect(page).to have_content(debate2.title)
       expect(page).to have_content(debate4.title)
+      expect(page).to have_content(debate5.title)
       expect(page).to_not have_content(debate1.title)
       expect(page).to_not have_content(debate3.title)
     end


### PR DESCRIPTION
Fixes #403

No estoy del todo contento con la implementación de `Debate.search`, pero la alternativa es una trozo bastante importante de SQL manual, ya que el `join(:tags)` más un nuevo condicional `OR` en la query actual ejecuta el join con un `INNER JOIN`, lo que excluye de la búsqueda debates que no estén etiquetados en absoluto pero sí tengan el contenido buscado. Ya me decís.