### PR TITLE
Document validation

### DIFF
--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -12,8 +12,9 @@ class Verification::Residence
 
   validates :postal_code, length: { is: 5 }
 
-  validate :residence_in_madrid
+  validate :allowed_age
   validate :document_number_uniqueness
+  validate :residence_in_madrid
 
   def initialize(attrs={})
     self.date_of_birth = parse_date('date_of_birth', attrs)
@@ -45,6 +46,11 @@ class Verification::Residence
       Lock.increase_tries(user)
     end
     self.date_of_birth = string_to_date(date_of_birth)
+  end
+
+  def allowed_age
+    return if errors[:date_of_birth].any?
+    errors.add(:date_of_birth, I18n.t('verification.residence.new.error_not_allowed_age')) unless self.date_of_birth <= 16.years.ago
   end
 
   def store_failed_attempt

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -19,7 +19,7 @@ class Verification::Residence
     self.date_of_birth = parse_date('date_of_birth', attrs)
     attrs = remove_date('date_of_birth', attrs)
     super
-    self.document_number.upcase! unless self.document_number.blank?
+    clean_document_number
   end
 
   def save
@@ -56,5 +56,11 @@ class Verification::Residence
       postal_code:     postal_code
     })
   end
+
+  private
+
+    def clean_document_number
+      self.document_number = self.document_number.gsub(/[^a-z0-9]+/i, "").upcase unless self.document_number.blank?
+    end
 
 end

--- a/app/models/verification/residence.rb
+++ b/app/models/verification/residence.rb
@@ -30,7 +30,7 @@ class Verification::Residence
   end
 
   def document_number_uniqueness
-    errors.add(:document_number, "Already in use") if User.where(document_number: document_number).any?
+    errors.add(:document_number, I18n.t('errors.messages.taken')) if User.where(document_number: document_number).any?
   end
 
   def residence_in_madrid

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -94,6 +94,7 @@ search:
 ignore_missing:
   - 'unauthorized.*'
   - 'errors.messages.blank'
+  - 'errors.messages.taken'
 
 ## Consider these keys used:
 ignore_unused:

--- a/config/locales/verification.en.yml
+++ b/config/locales/verification.en.yml
@@ -22,6 +22,7 @@ en:
         verify_residence: "Verify residence"
         form_errors: "prevented your residence verification"
         error_verifying_census: "The census of the city of Madrid could not verify your information. Pero revise de information and try again or get in touch with us."
+        error_not_allowed_age: "You need yo be at least 16 years old"
       create:
         flash:
           success: "Residence verified"

--- a/config/locales/verification.es.yml
+++ b/config/locales/verification.es.yml
@@ -22,6 +22,7 @@ es:
         verify_residence: "Verificar residencia"
         form_errors: "evitaron verificar tu residencia"
         error_verifying_census: "El Padrón de Madrid no pudo verificar tu información. Revisa la información ó ponte en contacto con nosotros."
+        error_not_allowed_age: "Hay que tener al menos 16 años"
       create:
         flash:
           success: "Residencia verificada"

--- a/spec/models/residence_spec.rb
+++ b/spec/models/residence_spec.rb
@@ -18,9 +18,15 @@ describe Verification::Residence do
 
       it "should not be valid without a date of birth" do
         residence = Verification::Residence.new({"date_of_birth(3i)"=>"", "date_of_birth(2i)"=>"", "date_of_birth(1i)"=>""})
-        residence.valid?
+        expect(residence).to_not be_valid
         expect(residence.errors[:date_of_birth]).to include("can't be blank")
       end
+    end
+
+    it "should validate user has allowed age" do
+        residence = Verification::Residence.new({"date_of_birth(3i)"=>"1", "date_of_birth(2i)"=>"1", "date_of_birth(1i)"=>"#{5.year.ago.year}"})
+        expect(residence).to_not be_valid
+        expect(residence.errors[:date_of_birth]).to include("You need yo be at least 16 years old")
     end
 
     it "should validate uniquness of document_number" do
@@ -38,6 +44,7 @@ describe Verification::Residence do
       residence.terms_of_service = nil
       expect(residence).to_not be_valid
     end
+
   end
 
   describe "new" do

--- a/spec/models/residence_spec.rb
+++ b/spec/models/residence_spec.rb
@@ -31,7 +31,7 @@ describe Verification::Residence do
       residence2 = build(:verification_residence)
 
       residence.valid?
-      expect(residence.errors[:document_number]).to include("Already in use")
+      expect(residence.errors[:document_number]).to include("has already been taken")
     end
 
     it "should validate census terms" do

--- a/spec/models/residence_spec.rb
+++ b/spec/models/residence_spec.rb
@@ -45,6 +45,11 @@ describe Verification::Residence do
       residence = Verification::Residence.new({document_number: "x1234567z"})
       expect(residence.document_number).to eq("X1234567Z")
     end
+
+    it "should remove all characters except numbers and letters" do
+      residence = Verification::Residence.new({document_number: " 12.345.678 - B"})
+      expect(residence.document_number).to eq("12345678B")
+    end
   end
 
   describe "save" do


### PR DESCRIPTION
Añadido método para limpiar el DNI, elimina cualquier cosa que no sean números y letras y envía al padrón siempre el mismo formáto con la letra en mayusculas
Añadida verificación de que solo los mayores de 16 años puedan verificar su cuenta.
Del último punto del issue, los ceros antes del dni se encarga el padrón.
Closes #498 