### PR TITLE
Moderating comments

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -4,7 +4,7 @@ class Admin::CommentsController < Admin::BaseController
   before_action :load_comment, only: [:confirm_hide, :restore]
 
   def index
-    @comments = Comment.only_hidden.send(@current_filter).order(hidden_at: :desc).page(params[:page])
+    @comments = Comment.only_hidden.with_visible_author.send(@current_filter).order(hidden_at: :desc).page(params[:page])
   end
 
   def confirm_hide

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,10 +18,9 @@ class Comment < ActiveRecord::Base
   belongs_to :user, -> { with_hidden }
 
   scope :recent, -> { order(id: :desc) }
-
   scope :sort_for_moderation, -> { order(flags_count: :desc, updated_at: :desc) }
-
   scope :for_render, -> { with_hidden.includes(user: :organization) }
+  scope :with_visible_author, -> { joins(:user).where("users.hidden_at IS NULL") }
 
   after_create :call_after_commented
 

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -9,8 +9,12 @@
     <li id="<%= dom_id(comment) %>">
       <div class="row">
         <div class="small-12 medium-8 column">
-          <%= text_with_links comment.body %>
-          <%= link_to comment.commentable.title, comment.commentable %>
+          <%= text_with_links comment.body %><br>
+          <% if comment.commentable.hidden? %>
+            (<%= t("admin.comments.index.hidden_#{comment.commentable_type.downcase}") %>: <%= comment.commentable.title %>)
+          <% else %>
+            <%= link_to comment.commentable.title, comment.commentable %>
+          <% end %>
         </div>
         <div class="small-6 medium-4 column text-right">
           <%= link_to t("admin.actions.restore"),

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -108,6 +108,7 @@ ignore_unused:
   - 'admin.proposals.index.filter*'
   - 'admin.organizations.index.filter*'
   - 'admin.users.index.filter*'
+  - 'admin.comments.index.hidden_*'
   - 'moderation.comments.index.filter*'
   - 'moderation.debates.index.filter*'
   - 'moderation.proposals.index.filter*'

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -3,6 +3,7 @@ en:
     models:
       comment: Comment
       debate: Debate
+      proposal: Proposal
       tag: Topic
       user: User
       vote: Vote

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -59,6 +59,8 @@ en:
     comments:
       index:
         title: Hidden comments
+        hidden_proposal: "Hidden proposal"
+        hidden_debate: "Hidden debate"
         filter: Filter
         filters:
           all: All

--- a/config/locales/admin.es.yml
+++ b/config/locales/admin.es.yml
@@ -59,6 +59,8 @@ es:
     comments:
       index:
         title: Comentarios ocultos
+        hidden_proposal: "Propuesta oculta"
+        hidden_debate: "Debate oculto"
         filter: Filtro
         filters:
           all: Todos


### PR DESCRIPTION
Se eliminan de el interfaz de administración los comentarios que estén ocultos porque su autor ha sido bloqueado.

Ademas se añade la información de si un comentario oculto lo es de un debate/propuesta que ha sido ocultado/a posteriormente.

Ref #423 