### PR TITLE
Comments count

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -75,6 +75,10 @@ class Comment < ActiveRecord::Base
     commentable_type.constantize.reset_counters(commentable_id, :comments)
   end
 
+  def after_restore
+    commentable_type.constantize.reset_counters(commentable_id, :comments)
+  end
+
   def reply?
     !root?
   end

--- a/lib/tasks/comments.rake
+++ b/lib/tasks/comments.rake
@@ -1,0 +1,9 @@
+namespace :comments do
+
+  desc "Recalculates all the comment counters for debates and proposals"
+  task count: :environment do
+    Debate.all.pluck(:id).each{ |id| Debate.reset_counters(id, :comments) }
+    Proposal.all.pluck(:id).each{ |id| Proposal.reset_counters(id, :comments) }
+  end
+
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,13 +8,15 @@ describe Comment do
     expect(comment).to be_valid
   end
 
-  it "should update cache_counter in debate after hide" do
+  it "updates cache_counter in debate after hide and restore" do
     debate  = create(:debate)
     comment = create(:comment, commentable: debate)
 
     expect(debate.reload.comments_count).to eq(1)
     comment.hide
     expect(debate.reload.comments_count).to eq(0)
+    comment.restore
+    expect(debate.reload.comments_count).to eq(1)
   end
 
   describe "#as_administrator?" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,7 +4,7 @@ describe Comment do
 
   let(:comment) { build(:comment) }
 
-  it "should be valid" do
+  it "is valid" do
     expect(comment).to be_valid
   end
 
@@ -18,7 +18,7 @@ describe Comment do
   end
 
   describe "#as_administrator?" do
-    it "should be true if comment has administrator_id, false otherway" do
+    it "is true if comment has administrator_id, false otherway" do
       expect(comment).not_to be_as_administrator
 
       comment.administrator_id = 33
@@ -28,7 +28,7 @@ describe Comment do
   end
 
   describe "#as_moderator?" do
-    it "should be true if comment has moderator_id, false otherway" do
+    it "is true if comment has moderator_id, false otherway" do
       expect(comment).not_to be_as_moderator
 
       comment.moderator_id = 21
@@ -40,27 +40,27 @@ describe Comment do
   describe "cache" do
     let(:comment) { create(:comment) }
 
-    it "should expire cache when it has a new vote" do
+    it "expires cache when it has a new vote" do
       expect { create(:vote, votable: comment) }
       .to change { comment.updated_at }
     end
 
-    it "should expire cache when hidden" do
+    it "expires cache when hidden" do
       expect { comment.hide }
       .to change { comment.updated_at }
     end
 
-    it "should expire cache when the author is hidden" do
+    it "expires cache when the author is hidden" do
       expect { comment.user.hide }
       .to change { [comment.reload.updated_at, comment.author.updated_at] }
     end
 
-    it "should expire cache when the author changes" do
+    it "expires cache when the author changes" do
       expect { comment.user.update(username: "Isabel") }
       .to change { [comment.reload.updated_at, comment.author.updated_at] }
     end
 
-    it "should expire cache when the author's organization get verified" do
+    it "expires cache when the author's organization get verified" do
       create(:organization, user: comment.user)
       expect { comment.user.organization.verify }
       .to change { [comment.reload.updated_at, comment.author.updated_at] }


### PR DESCRIPTION
Comments increase count in their root when they are restored. Also included a rake task to recalculate the root counts.

Fixes #452

Closes #484. Closes #477