### PR TITLE
changes moderation/proposals: only show flagged except in 'All' filter

### DIFF
--- a/app/models/concerns/flaggable.rb
+++ b/app/models/concerns/flaggable.rb
@@ -4,8 +4,8 @@ module Flaggable
   included do
     has_many :flags, as: :flaggable
     scope :flagged, -> { where("flags_count > 0") }
-    scope :pending_flag_review, -> { where(ignored_flag_at: nil, hidden_at: nil) }
-    scope :with_ignored_flag, -> { where.not(ignored_flag_at: nil).where(hidden_at: nil) }
+    scope :pending_flag_review, -> { flagged.where(ignored_flag_at: nil, hidden_at: nil) }
+    scope :with_ignored_flag, -> { flagged.where.not(ignored_flag_at: nil).where(hidden_at: nil) }
   end
 
   def ignored_flag?


### PR DESCRIPTION
Lo moderadores se están liando al ver propuestas normales en 'Pendientes'.
Esta PR hace que en Pendientes y en Marcadas como Revisadas solamente se muestren prpuestas denunciadas. El filtro Todas queda para la moderación en bloque de propuestas de todo tipo.

