### PR TITLE
Fix mailers

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,8 @@
+module MailerHelper
+
+  def commentable_url(commentable)
+    return debate_url(commentable) if commentable.is_a?(Debate)
+    return proposal_url(commentable) if commentable.is_a?(Proposal)
+  end
+
+end

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -1,5 +1,6 @@
 class Mailer < ApplicationMailer
   helper :text_with_links
+  helper :mailer
 
   def comment(comment)
     @comment = comment

--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -4,23 +4,23 @@ class Mailer < ApplicationMailer
 
   def comment(comment)
     @comment = comment
-    @debate = comment.debate
-    mail(to: @debate.author.email, subject: t('mailer.comment.subject'))
+    @commentable = comment.commentable
+    mail(to: @commentable.author.email, subject: t('mailers.comment.subject', commentable: t("activerecord.models.#{@commentable.class.name.downcase}").downcase)) if @commentable.present? && @commentable.author.present?
   end
 
   def reply(reply)
     @reply = reply
-    @debate = @reply.debate
+    @commentable = @reply.commentable
     parent = Comment.find(@reply.parent_id)
     @recipient = parent.author
-    mail(to: @recipient.email, subject: t('mailer.reply.subject'))
+    mail(to: @recipient.email, subject: t('mailers.reply.subject')) if @commentable.present? && @recipient.present?
   end
 
   def email_verification(user, recipient, token)
     @user = user
     @recipient = recipient
     @token = token
-    mail(to: @recipient, subject: "Verifica tu email")
+    mail(to: @recipient, subject: t('mailers.email_verification.subject'))
   end
 
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -36,10 +36,6 @@ class Comment < ActiveRecord::Base
     c_type.constantize.find(c_id)
   end
 
-  def debate
-    commentable if commentable.class == Debate
-  end
-
   def author_id
     user_id
   end

--- a/app/views/mailer/comment.html.erb
+++ b/app/views/mailer/comment.html.erb
@@ -5,11 +5,11 @@
   </h1>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.comment.hi") %> <strong><%= @debate.author.name %></strong>,
+    <%= t("mailers.comment.hi") %> <strong><%= @commentable.author.name %></strong>,
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.comment.new_comment_by_html", commenter: @comment.author.name) %> <%= link_to @debate.title, debate_url(@debate), style: "color: #2895F1; text-decoration:none;" %>
+    <%= t("mailers.comment.new_comment_by_html", commenter: @comment.author.name) %> <%= link_to @commentable.title, commentable_url(@commentable), style: "color: #2895F1; text-decoration:none;" %>
   </p>
 
   <p style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">

--- a/app/views/mailer/reply.html.erb
+++ b/app/views/mailer/reply.html.erb
@@ -9,7 +9,7 @@
   </p>
 
   <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-weight: normal;line-height: 24px;">
-    <%= t("mailers.reply.new_reply_by_html", commenter: @reply.author.name) %> <%= link_to @debate.title, debate_url(@debate), style: "color: #2895F1; text-decoration:none;" %>
+    <%= t("mailers.reply.new_reply_by_html", commenter: @reply.author.name) %> <%= link_to @commentable.title, commentable_url(@commentable), style: "color: #2895F1; text-decoration:none;" %>
   </p>
 
   <p style="border-left: 2px solid #DEE0E3;font-family: 'Open Sans','Helvetica Neue',arial,sans-serif;font-size: 14px;font-style: italic;font-weight: normal;line-height: 24px;margin-left: 20px;padding: 10px;">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,11 +300,6 @@ en:
     check: Select
     check_all: All
     check_none: None
-  mailer:
-    comment:
-      subject: Someone has commented on your debate
-    reply:
-      subject: Someone has replied to your comment
   unauthorized:
     default: "You are not authorized to access this page."
     manage:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -300,11 +300,6 @@ es:
     check: Seleccionar
     check_all: Todos
     check_none: Ninguno
-  mailer:
-    comment:
-      subject: Alguien ha comentado en tu propuesta
-    reply:
-      subject: Alguien ha respondido a tu comentario
   unauthorized:
     default: "No tienes permiso para acceder a esta página."
     manage:

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -1,14 +1,17 @@
 en:
   mailers:
     comment:
+      subject: "Someone has commented on your %{commentable}"
       hi: Hello
-      title: New comment on your debate
+      title: New comment
       new_comment_by_html: "There is a new comment by <b>%{commenter}</b> on"
     reply:
+      subject: Someone has replied to your comment
       hi: Hello
       title: New reply on your comment
       new_reply_by_html: "There'is a new reply by <b>%{commenter}</b> to your comment on"
     email_verification:
+      subject: Verify your email
       title: Please verify yourself
       instructions_html: "We need to verify you using this email, which we got from the Census. %{verification_link}"
       click_here_to_verify: "Please click here to verify yourself"

--- a/config/locales/mailers.es.yml
+++ b/config/locales/mailers.es.yml
@@ -1,14 +1,17 @@
 es:
   mailers:
     comment:
+      subject: "Alguien ha comentado en tu %{commentable}"
       hi: Hola
-      title: Nuevo comentario en tu debate
+      title: Nuevo comentario
       new_comment_by_html: "Hay un nuevo comentario de <b>%{commenter}</b> en"
     reply:
+      subject: Alguien ha respondido a tu comentario
       hi: Hola
       title: Nueva respuesta a tu comentario
       new_reply_by_html: "Hay una nueva respuesta de <b>%{commenter}</b> a tu comentario en"
     email_verification:
+      subject: Verifica tu email
       title:  Verifica tu cuenta con el siguiente enlace
       instructions_html: "Para terminar de verificar tu cuenta de usuario en el Portal de Gobierno Abierto del Ayuntamiento de Madrid, necesitamos que pulses %{verification_link}."
       click_here_to_verify: "en este enlace"

--- a/spec/support/common_actions.rb
+++ b/spec/support/common_actions.rb
@@ -44,13 +44,14 @@ module CommonActions
     click_button 'Send me reset password'
   end
 
-  def comment_on(debate, user = nil)
+  def comment_on(commentable, user = nil)
     user ||= create(:user)
 
     login_as(user)
-    visit debate_path(debate)
+    commentable_path = commentable.is_a?(Proposal) ? proposal_path(commentable) : debate_path(commentable)
+    visit commentable_path
 
-    fill_in "comment-body-debate_#{debate.id}", with: 'Have you thought about...?'
+    fill_in "comment-body-#{commentable.class.name.downcase}_#{commentable.id}", with: 'Have you thought about...?'
     click_button 'Publish comment'
 
     expect(page).to have_content 'Have you thought about...?'


### PR DESCRIPTION
No se están enviando los mails correspondientes a comentarios/respuestas en Propuestas porque el código del mailer era [dependiente de debate](https://github.com/AyuntamientoMadrid/participacion/blob/master/app/mailers/mailer.rb#L6). Esto es la causa del error más frecuente en rollbar esta última semana.

Esta PR elimina esa dependencia en el mailer, las vistas y las specs, para que todo vaya via commentable.