### PR TITLE
adds extra info for proposals in admin listing

### DIFF
--- a/app/views/admin/proposals/index.html.erb
+++ b/app/views/admin/proposals/index.html.erb
@@ -11,7 +11,15 @@
         <strong><%= proposal.title %></strong>
         <br>
         <div class="moderation-description">
+          <p><%= proposal.summary %></p>
           <%= proposal.description %>
+          <% if proposal.external_url.present? %>
+            <p><%= text_with_links proposal.external_url %></p>
+          <% end %>
+          <% if proposal.video_url.present? %>
+            <p><%= text_with_links proposal.video_url %></p>
+          <% end %>
+          <p><%= proposal.question %></p>
         </div>
       </td>
       <td>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -124,6 +124,7 @@ FactoryGirl.define do
     description          'Proposal description'
     question             'Proposal question'
     external_url         'http://external_documention.es'
+    video_url            'http://video_link.com'
     responsible_name     'John Snow'
     terms_of_service     '1'
     association :author, factory: :user

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -7,6 +7,18 @@ feature 'Admin proposals' do
     login_as(admin.user)
   end
 
+  scenario 'List shows all relevant info' do
+    proposal = create(:proposal, :hidden)
+    visit admin_proposals_path
+
+    expect(page).to have_content(proposal.title)
+    expect(page).to have_content(proposal.summary)
+    expect(page).to have_content(proposal.description)
+    expect(page).to have_content(proposal.question)
+    expect(page).to have_content(proposal.external_url)
+    expect(page).to have_content(proposal.video_url)
+  end
+
   scenario 'Restore' do
     proposal = create(:proposal, :hidden)
     visit admin_proposals_path


### PR DESCRIPTION
Esta PR hace que el admin de propuestas muestre el resumen, la pregunta y los links external y de video porque también son campos que se pueden usar para el mal y por los que ha podido ser moderada una propuesta.