### PR TITLE
Hide admin restored

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -14,6 +14,7 @@ class Admin::CommentsController < Admin::BaseController
 
   def restore
     @comment.restore
+    @comment.ignore_flag
     Activity.log(current_user, :restore, @comment)
     redirect_to request.query_parameters.merge(action: :index)
   end

--- a/app/controllers/admin/debates_controller.rb
+++ b/app/controllers/admin/debates_controller.rb
@@ -14,6 +14,7 @@ class Admin::DebatesController < Admin::BaseController
 
   def restore
     @debate.restore
+    @debate.ignore_flag
     Activity.log(current_user, :restore, @debate)
     redirect_to request.query_parameters.merge(action: :index)
   end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -14,6 +14,7 @@ class Admin::ProposalsController < Admin::BaseController
 
   def restore
     @proposal.restore
+    @proposal.ignore_flag
     Activity.log(current_user, :restore, @proposal)
     redirect_to request.query_parameters.merge(action: :index)
   end

--- a/spec/features/admin/comments_spec.rb
+++ b/spec/features/admin/comments_spec.rb
@@ -35,6 +35,7 @@ feature 'Admin comments' do
     expect(page).to_not have_content(comment.body)
 
     expect(comment.reload).to_not be_hidden
+    expect(comment).to be_ignored_flag
   end
 
   scenario "Confirm hide" do

--- a/spec/features/admin/debates_spec.rb
+++ b/spec/features/admin/debates_spec.rb
@@ -16,6 +16,7 @@ feature 'Admin debates' do
     expect(page).to_not have_content(debate.title)
 
     expect(debate.reload).to_not be_hidden
+    expect(debate).to be_ignored_flag
   end
 
   scenario 'Confirm hide' do

--- a/spec/features/admin/proposals_spec.rb
+++ b/spec/features/admin/proposals_spec.rb
@@ -28,6 +28,7 @@ feature 'Admin proposals' do
     expect(page).to_not have_content(proposal.title)
 
     expect(proposal.reload).to_not be_hidden
+    expect(proposal).to be_ignored_flag
   end
 
   scenario 'Confirm hide' do


### PR DESCRIPTION
Cuando un admin hace restore de algún debate/propuesta/comentario, ahora mismo éste vuelve a salir como pendiente en moderación si tiene flags. 

Esta PR añade el ignore_flag a las acciones del admin para que no vuelvan a aparecer como pendientes a los moderadores.