### PR TITLE
Document management

### DIFF
--- a/app/controllers/management/document_verifications_controller.rb
+++ b/app/controllers/management/document_verifications_controller.rb
@@ -1,5 +1,6 @@
 class Management::DocumentVerificationsController < Management::BaseController
 
+  before_action :clean_document_number, only: :check
   before_action :set_document, only: :check
 
   def index
@@ -39,6 +40,10 @@ class Management::DocumentVerificationsController < Management::BaseController
   def set_document
     session[:document_type] = params[:document_verification][:document_type]
     session[:document_number] = params[:document_verification][:document_number]
+  end
+
+  def clean_document_number
+    params[:document_verification][:document_number] = params[:document_verification][:document_number].gsub(/[^a-z0-9]+/i, "").upcase unless params[:document_verification][:document_number].blank?
   end
 
 end

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -27,7 +27,7 @@
         <nav class="top-bar" data-topbar role="navigation">
           <ul class="title-area">
             <li class="name">
-              <%= link_to root_path do %>
+              <%= link_to management_root_path do %>
                 <%= image_tag('header_logo_madrid.png', class: 'left', size: '96x96') %>
                 <%= t("layouts.header.open_gov", open: "<strong>#{t('layouts.header.open')}</strong>").html_safe %> <span>|</span> <span class="logo-site"><%= t("management.dashboard.index.title") %></span>
               <% end %>

--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -17,10 +17,10 @@ en:
         title: "Management"
     account_info:
       identified_label: "Identified as:"
-      username_label: "Username"
-      email_label: "Email"
-      document_number_label: "Document number"
-      document_type_label: "Document type"
+      username_label: "Username:"
+      email_label: "Email:"
+      document_number_label: "Document number:"
+      document_type_label: "Document type:"
       change_user: "Change user"
     sessions:
       signed_out: "Signed out successfully."

--- a/spec/features/management/document_verifications_spec.rb
+++ b/spec/features/management/document_verifications_spec.rb
@@ -53,4 +53,13 @@ feature 'DocumentVerifications' do
     expect(page).to have_content "Please introduce the email used on the account"
   end
 
+  scenario 'Document number is format-standarized' do
+
+    visit management_document_verifications_path
+    fill_in 'document_verification_document_number', with: '12345 - h'
+    click_button 'Check'
+
+    expect(page).to have_content "Document number: 12345H"
+  end
+
 end


### PR DESCRIPTION
La validación en /management del dni fallaba si la letra está en minúsculas.
Esta PR limpia primero el document number de caracteres raros y pone la letra en mayúscula siempre.

Referencia: #573 - "Permitir Letra minuscula en DNI"