### PR TITLE
defaults proposal print list to confidence_score

### DIFF
--- a/app/controllers/management/proposals_controller.rb
+++ b/app/controllers/management/proposals_controller.rb
@@ -6,7 +6,7 @@ class Management::ProposalsController < Management::BaseController
   before_action :set_proposal, only: [:vote, :show]
   before_action :parse_search_terms, only: :index
 
-  has_orders %w{hot_score confidence_score created_at most_commented random}, only: [:index, :print]
+  has_orders %w{confidence_score hot_score created_at most_commented random}, only: [:index, :print]
 
   def vote
     @proposal.register_vote(current_user, 'yes')

--- a/spec/features/management/proposals_spec.rb
+++ b/spec/features/management/proposals_spec.rb
@@ -117,16 +117,14 @@ feature 'Proposals' do
     end
 
     scenario "Filtering proposals to be printed", :js do
-      create(:proposal, title: 'Best proposal').update_column(:confidence_score, 10)
       create(:proposal, title: 'Worst proposal').update_column(:confidence_score, 2)
+      create(:proposal, title: 'Best proposal').update_column(:confidence_score, 10)
       create(:proposal, title: 'Medium proposal').update_column(:confidence_score, 5)
 
       user = create(:user, :level_two)
       login_managed_user(user)
 
       click_link "Print proposals"
-
-      select 'most supported', from: 'order-selector'
 
       expect(page).to have_selector('.js-order-selector[data-order="confidence_score"]')
 
@@ -135,8 +133,17 @@ feature 'Proposals' do
         expect('Medium proposal').to appear_before('Worst proposal')
       end
 
-      expect(current_url).to include('order=confidence_score')
+      select 'newest', from: 'order-selector'
+
+      expect(page).to have_selector('.js-order-selector[data-order="created_at"]')
+
+      expect(current_url).to include('order=created_at')
       expect(current_url).to include('page=1')
+
+      within '#proposals' do
+        expect('Medium proposal').to appear_before('Best proposal')
+        expect('Best proposal').to appear_before('Worst proposal')
+      end
     end
 
   end


### PR DESCRIPTION
Cambia el filtro por defecto en la lista de propuestas para imprimir de /management, ahora es las "más apoyadas" en vez de las "más activas hoy".

Referencia: #573 - "En la sección de imprimir mostrar las más apoyadas por defecto"