### PR TITLE
Changes notice for managed user session closed

### DIFF
--- a/config/locales/management.en.yml
+++ b/config/locales/management.en.yml
@@ -24,7 +24,7 @@ en:
       change_user: "Change user"
     sessions:
       signed_out: "Signed out successfully."
-      signed_out_managed_user: "Signed out successfully."
+      signed_out_managed_user: "User session signed out successfully."
     proposals:
       print:
        print_button: Print

--- a/config/locales/management.es.yml
+++ b/config/locales/management.es.yml
@@ -24,7 +24,7 @@ es:
       change_user: "Cambiar usuario"
     sessions:
       signed_out: "Has cerrado la sesión correctamente."
-      signed_out_managed_user: "Has cerrado la sesión correctamente."
+      signed_out_managed_user: "Se ha cerrado correctamente la sesión del usuario."
     proposals:
       print:
        print_button: Imprimir

--- a/spec/features/management/managed_users_spec.rb
+++ b/spec/features/management/managed_users_spec.rb
@@ -114,7 +114,7 @@ feature 'Managed User' do
       click_link "Change user"
     end
 
-    expect(page).to have_content "Signed out successfully."
+    expect(page).to have_content "User session signed out successfully."
     expect(current_path).to eq(management_root_path)
   end
 


### PR DESCRIPTION
Esta PR hace que se muestre un mensaje distinto al cerrar la sesión de un managed_user que al cerrar la sesión de un manager.

Referencia: #573 - "Diferenciar el mensaje de cerrar sesión entre managers y usuarios asistidos"