### PR TITLE
Update comments count when commenting on a debate or proposal

### DIFF
--- a/app/assets/javascripts/comments.js.coffee
+++ b/app/assets/javascripts/comments.js.coffee
@@ -2,9 +2,16 @@ App.Comments =
 
   add_comment: (parent_id, response_html) ->
     $(response_html).insertAfter($("#js-comment-form-#{parent_id}"))
+    this.update_comments_count()
 
   add_reply: (parent_id, response_html) ->
     $("##{parent_id} .comment-children:first").prepend($(response_html))
+    this.update_comments_count()
+
+  update_comments_count: (parent_id) ->
+    $(".js-comments-count").each ->
+      new_val = $(this).text().trim().replace /\d+/, (match) -> parseInt(match, 10) + 1
+      $(this).text(new_val)
 
   display_error: (field_with_errors, error_html) ->
     $(error_html).insertAfter($("#{field_with_errors}"))

--- a/app/views/debates/_comments.html.erb
+++ b/app/views/debates/_comments.html.erb
@@ -4,7 +4,7 @@
       <div id="comments" class="small-12 column">
         <h2>
           <%= t("debates.show.comments_title") %>
-          <span>(<%= @debate.comments_count %>)</span>
+          <span class="js-comments-count">(<%= @debate.comments_count %>)</span>
         </h2>
 
         <% if user_signed_in? %>

--- a/app/views/proposals/_comments.html.erb
+++ b/app/views/proposals/_comments.html.erb
@@ -4,7 +4,7 @@
       <div id="comments" class="small-12 column">
         <h2>
           <%= t("proposals.show.comments_title") %>
-          <span>(<%= @proposal.comments_count %>)</span>
+          <span class="js-comments-count">(<%= @proposal.comments_count %>)</span>
         </h2>
 
         <% if user_signed_in? %>

--- a/spec/features/comments/debates_spec.rb
+++ b/spec/features/comments/debates_spec.rb
@@ -85,6 +85,7 @@ feature 'Commenting debates' do
 
     within "#comments" do
       expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content '(1)'
     end
   end
 

--- a/spec/features/comments/proposals_spec.rb
+++ b/spec/features/comments/proposals_spec.rb
@@ -85,6 +85,7 @@ feature 'Commenting proposals' do
 
     within "#comments" do
       expect(page).to have_content 'Have you thought about...?'
+      expect(page).to have_content '(1)'
     end
   end
 


### PR DESCRIPTION
Not sure it fixes #646 completely, but you just need to add the class `.js-comments-count` to the container and the JS will automatically look for every integer and increment it in one.

A different approach would be getting the count from the server, but this might cause problems if there are new comments on the back that are still not in the client.