### PR TITLE
Check letter verification codes as integers

### DIFF
--- a/app/models/verification/letter.rb
+++ b/app/models/verification/letter.rb
@@ -28,7 +28,7 @@ class Verification::Letter
 
   def validate_correct_code
     return if errors.include?(:verification_code)
-    if user.try(:letter_verification_code) != verification_code
+    if user.try(:letter_verification_code).to_i != verification_code.to_i
       errors.add(:verification_code, I18n.t('verification.letter.errors.incorrect_code'))
     end
   end

--- a/spec/features/verification/letter_spec.rb
+++ b/spec/features/verification/letter_spec.rb
@@ -68,6 +68,23 @@ feature 'Verify Letter' do
       expect(current_path).to eq(account_path)
     end
 
+    scenario "Valid verification of user failing to add trailing zeros" do
+      user = create(:user, residence_verified_at: Time.now,
+                           confirmed_phone:       "611111111",
+                           letter_verification_code: "012345")
+
+      login_as(user)
+      visit edit_letter_path
+
+      fill_in "verification_letter_email", with: user.email
+      fill_in "verification_letter_password", with: user.password
+      fill_in "verification_letter_verification_code", with: "12345"
+      click_button "Verify my account"
+
+      expect(page).to have_content "Your account has been verified"
+      expect(current_path).to eq(account_path)
+    end
+
     scenario "Valid verification user not logged in" do
       user = create(:user, residence_verified_at: Time.now,
                            confirmed_phone:       "611111111",

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -48,6 +48,14 @@ describe 'Verification::Letter' do
       expect(letter.valid?).to eq(true)
       expect(letter.errors).to be_empty
     end
+
+    it "ignores trailing zeros" do
+      letter.user.update(letter_verification_code: "003456")
+      letter.verification_code = "3456"
+
+      expect(letter.valid?).to eq(true)
+      expect(letter.errors).to be_empty
+    end
   end
 
 end


### PR DESCRIPTION
Hay usuarios a los que les falla el código de verificación porque no introducen los ceros a la izquierda.
Con este cambio comparamos códigos despuñes de convertirlos a enteros y evitamos el problema.