### PR TITLE
Adds message for deleted account notice

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -33,7 +33,11 @@ en:
       updated: "Your password has been changed successfully. Authentication successful."
       updated_not_active: "Your password has been changed successfully."
     registrations:
-      destroyed: "Goodbye! Your account has been cancelled. We hope to see you again soon."
+      destroyed:
+        "Goodbye! Your account has been cancelled. We hope to see you again soon. In accordance with your request, personal data registered as
+        a user of the site decide.madrid.es and form part of the file 'Gestión de procesos participativos' under the responsibility of the
+        Dirección General de Participación Ciudadana, they have been canceled under the terms of the provisions of Article 16 of the
+        Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal and Article 31 of its Reglamento de desarrollo (RD 1720/2007)."
       signed_up: "Welcome! You have been authenticated."
       signed_up_but_inactive: "Your registration was successful, but you could not be signed in because your account has not been activated."
       signed_up_but_locked: "Your registration was successful, but you could not be signed in because your account is locked."

--- a/config/locales/devise.es.yml
+++ b/config/locales/devise.es.yml
@@ -31,7 +31,11 @@ es:
       updated: "Tu contraseña ha cambiado correctamente. Has sido identificado correctamente."
       updated_not_active: "Tu contraseña se ha cambiado correctamente."
     registrations:
-      destroyed: "¡Adiós! Tu cuenta ha sido cancelada. Esperamos volver a verte pronto."
+      destroyed:
+        "¡Adiós! Tu cuenta ha sido cancelada. Esperamos volver a verte pronto. Le informamos que de conformidad con su petición,
+        sus datos personales registrados como usuario de la Web decide.madrid.es y que forman parte del fichero 'Gestión de procesos participativos'
+        cuyo responsable es la Dirección General de Participación Ciudadana, han sido cancelados en los términos de lo previsto en el artículo 16 de la
+        Ley Orgánica 15/1999 de Protección de Datos de Carácter Personal y del artículo 31 de su Reglamento de desarrollo (RD 1720/2007)."
       signed_up: "¡Bienvenido! Has sido identificado."
       signed_up_but_inactive: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta no ha sido activada."
       signed_up_but_locked: "Te has registrado correctamente, pero no has podido iniciar sesión porque tu cuenta está bloqueada."


### PR DESCRIPTION
Añade un nuevo texto al darse de baja:

![delete account](https://cloud.githubusercontent.com/assets/631897/10862878/364e9a5a-7fbb-11e5-890a-51b400303614.png)
