### PR TITLE
removes hardcoding of proposal's supports

### DIFF
--- a/app/views/proposals/_votes.html.erb
+++ b/app/views/proposals/_votes.html.erb
@@ -10,8 +10,8 @@
   <span class="total-supports">
     <%= t("proposals.proposal.supports", count: proposal.total_votes) %>&nbsp;
     <span>
-      <abbr title="<%= t("proposals.proposal.census_percent") %>">
-        <%= t("proposals.proposal.supports_necessary") %>
+      <abbr title="<%= t("proposals.proposal.reason_for_supports_necessary") %>">
+        <%= t("proposals.proposal.supports_necessary", number: number_with_delimiter(Proposal.votes_needed_for_success)) %>
       </abbr>
     </span>
   </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,8 +184,8 @@ en:
         zero: "No supports"
         one: "1 support"
         other: "%{count} supports"
-      supports_necessary: "53,726 supports needed"
-      census_percent: "2% of Census"
+      supports_necessary: "%{number} supports needed"
+      reason_for_supports_necessary: "2% of Census"
       total_percent: "100%"
       already_supported: "You have already supported this proposal. Share it!"
     form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -184,8 +184,8 @@ es:
         zero: "Sin apoyos"
         one: "1 apoyo"
         other: "%{count} apoyos"
-      supports_necessary: "53.726 apoyos necesarios"
-      census_percent: "2% del Censo"
+      supports_necessary: "%{number} apoyos necesarios"
+      reason_for_supports_necessary: "2% del Censo"
       total_percent: "100%"
       already_supported: "¡Ya has apoyado esta propuesta, compártela!"
     form:


### PR DESCRIPTION

El número de apoyos necesarios estaba todavía metido a pelo en el archivo de localización. 
Esta PR lo hace dinámico usando `Proposal.votes_needed_for_success`
Gracias @andion por [el aviso](https://github.com/AyuntamientoMadrid/participacion/commit/50dc4dbce4488b6a94dc9558aed41705d5d7fd65#commitcomment-14161765)!