### PR TITLE
Avatar bug

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -14,13 +14,12 @@
         <% elsif comment.as_moderator? %>
           <%= image_tag("moderator_avatar.png", size: 32, class: "moderator-avatar left") %>
         <% else %>
-          <% if comment.user.organization? %>
+        <% if comment.user.hidden? || comment.user.erased? %>
+            <i class="icon-deleted user-deleted"></i>
+          <% elsif comment.user.organization? %>
             <%= image_tag("collective_avatar.png", size: 32, class: "avatar left") %>
           <% else %>
             <%= avatar_image(comment.user, seed: comment.user_id, size: 32, class: "left") %>
-          <% end %>
-          <% if comment.user.hidden? || comment.user.erased? %>
-            <i class="icon-deleted user-deleted"></i>
           <% end %>
         <% end %>
 

--- a/app/views/shared/_author_info.html.erb
+++ b/app/views/shared/_author_info.html.erb
@@ -1,11 +1,10 @@
-<%= avatar_image(resource.author, seed: resource.author_id, size: 32, class: 'author-photo') %>
-
 <% if resource.author.hidden? || resource.author.erased? %>
   <i class="icon-deleted author-deleted"></i>
   <span class="author">
       <%= t("shared.author_info.author_deleted") %>
   </span>
 <% else %>
+  <%= avatar_image(resource.author, seed: resource.author_id, size: 32, class: 'author-photo') %>
   <span class="author">
       <%= link_to resource.author.name, user_path(resource.author) %>
   </span>


### PR DESCRIPTION
Se estaba intentando generar avatares para los usuarios eliminados, lo que provocaba un fallo de js que impedía mostrar bien el resto de avatares. 
Ahora solo se crean los avatares para usuarios no eliminados.

Closes #671