### PR TITLE
Renaming header

### DIFF
--- a/app/views/layouts/_admin_header.html.erb
+++ b/app/views/layouts/_admin_header.html.erb
@@ -11,7 +11,7 @@
         <li class="name">
           <%= link_to root_path do %>
             <%= image_tag('header_logo_madrid.png', class: 'left', size: '96x96', alt: t("layouts.header.logo")) %>
-            <%= t("layouts.header.open_gov", open: "<strong>#{t('layouts.header.open')}</strong>").html_safe %> <span>|</span> <span class="logo-site"><%= t("admin.dashboard.index.title") %></span>
+            <%= t("layouts.header.participation_html") %> <span>|</span> <span class="logo-site"><%= t("admin.dashboard.index.title") %></span>
           <% end %>
         </li>
         <li class="toggle-topbar menu-icon"><a href="#"><span></span></a></li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
     <div class="row">
       <%= render "shared/locale_switcher" %>
       <div class="external-links">
-        <%= link_to t("layouts.header.participation"), root_path, class: ("selected" unless current_page?("/transparency") || current_page?("/opendata")) %>&nbsp;|
+        <%= link_to t("layouts.header.participation_html"), root_path, class: ("selected" unless current_page?("/transparency") || current_page?("/opendata")) %>&nbsp;|
         <%= link_to t("layouts.header.external_link_transparency"), "/transparency", class: ("selected" if current_page?("/transparency")) %>&nbsp;|
         <%= link_to t("layouts.header.external_link_opendata"), "/opendata", class: ("selected" if current_page?("/opendata")) %>
           &nbsp;|&nbsp;
@@ -44,7 +44,7 @@
               <%= t("layouts.header.open_gov", open: "#{t('layouts.header.open')}") %> <span>|</span>
               <span class="logo-site"><%= t("layouts.header.open_data") %></span>
             <% else %>
-               <%= t("layouts.header.participation") %>
+               <%= t("layouts.header.participation_html") %>
             <% end %>
 
           <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,16 +36,17 @@
         <li class="name">
           <%= link_to root_path do %>
             <%= image_tag('header_logo_madrid.png', class: 'show-for-medium-up left', size: '96x96', alt: t("layouts.header.logo")) %>
-            <%= t("layouts.header.open_gov", open: "#{t('layouts.header.open')}").html_safe %> <span>|</span>
-            <span class="logo-site">
-              <% if transparency_page? %>
-                <%= t("layouts.header.transparency") %>
-              <% elsif opendata_page? %>
-                <%= t("layouts.header.open_data") %>
-              <% else %>
-                <%= t("layouts.header.participation") %>
-              <% end %>
-            </span>
+
+            <% if transparency_page? %>
+              <%= t("layouts.header.open_gov", open: "#{t('layouts.header.open')}") %> <span>|</span>
+              <span class="logo-site"><%= t("layouts.header.transparency") %></span>
+            <% elsif opendata_page? %>
+              <%= t("layouts.header.open_gov", open: "#{t('layouts.header.open')}") %> <span>|</span>
+              <span class="logo-site"><%= t("layouts.header.open_data") %></span>
+            <% else %>
+               <%= t("layouts.header.participation") %>
+            <% end %>
+
           <% end %>
         </li>
       </ul>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title><%= content_for?(:title) ? yield(:title) : "Admin" %></title>
+    <title><%= content_for?(:title) ? yield(:title) : "Management" %></title>
     <%= stylesheet_link_tag  "application", media: "all" %>
     <%= stylesheet_link_tag  "print", media: "print" %>
     <%= javascript_include_tag "vendor/modernizr" %>

--- a/app/views/layouts/management.html.erb
+++ b/app/views/layouts/management.html.erb
@@ -29,7 +29,7 @@
             <li class="name">
               <%= link_to management_root_path do %>
                 <%= image_tag('header_logo_madrid.png', class: 'left', size: '96x96') %>
-                <%= t("layouts.header.open_gov", open: "<strong>#{t('layouts.header.open')}</strong>").html_safe %> <span>|</span> <span class="logo-site"><%= t("management.dashboard.index.title") %></span>
+                <%= t("layouts.header.participation_html") %> <span>|</span> <span class="logo-site"><%= t("management.dashboard.index.title") %></span>
               <% end %>
             </li>
             <li class="toggle-topbar menu-icon"><a href="#"><span></span></a></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
       external_link_blog_url: "/blog"
       open_gov: "%{open} government"
       open: "open"
-      participation: "Participation"
+      participation: "Madrid Decides"
       transparency: "Transparency"
       open_data: "Open data"
       open_city_title: "Love the city, and it will become a city you love."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
       external_link_blog_url: "/blog"
       open_gov: "%{open} government"
       open: "open"
-      participation: "Madrid Decides"
+      participation_html: "Madrid <strong>Decides</strong>"
       transparency: "Transparency"
       open_data: "Open data"
       open_city_title: "Love the city, and it will become a city you love."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -14,7 +14,7 @@ es:
       external_link_blog_url: "/blog"
       open_gov: "Gobierno %{open}"
       open: "abierto"
-      participation: "Participación"
+      participation: "Madrid Decide"
       transparency: "Transparencia"
       open_data: "Datos abiertos"
       open_city_title: "La ciudad que quieres será la ciudad que quieras."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -14,7 +14,7 @@ es:
       external_link_blog_url: "/blog"
       open_gov: "Gobierno %{open}"
       open: "abierto"
-      participation: "Madrid Decide"
+      participation_html: "Madrid <strong>Decide</strong>"
       transparency: "Transparencia"
       open_data: "Datos abiertos"
       open_city_title: "La ciudad que quieres será la ciudad que quieras."


### PR DESCRIPTION
Cambio de nombre de la página.
Deja de ser "Gobierno abierto: Participación" y ahora es "Madrid Decide"